### PR TITLE
Add CarbonComply module and mock APIs

### DIFF
--- a/src/app/api/org/[orgId]/alerts/route.ts
+++ b/src/app/api/org/[orgId]/alerts/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 
 export async function GET() {
-  /* Empty list → count = 0 */
-  return NextResponse.json({ items: [], count: 0 });
+  return NextResponse.json([
+    {
+      id: 1,
+      time: Date.now(),
+      source: "budget",
+      msg: "Forecast overshoot",
+      status: "open",
+    },
+  ]);
 }

--- a/src/app/api/org/[orgId]/projects/[projectId]/summary/route.ts
+++ b/src/app/api/org/[orgId]/projects/[projectId]/summary/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { projectId: string } }
+) {
+  return NextResponse.json({ id: params.projectId, name: "GreenShop" });
+}

--- a/src/app/api/org/[orgId]/projects/route.ts
+++ b/src/app/api/org/[orgId]/projects/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json([
+    { id: "p1", name: "GreenShop" }
+  ]);
+}

--- a/src/app/api/org/[orgId]/reports/route.ts
+++ b/src/app/api/org/[orgId]/reports/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json([
+    { id: "r1", period: "FY2026", link: "#" }
+  ]);
+}

--- a/src/app/org/[orgId]/comply/audit/page.tsx
+++ b/src/app/org/[orgId]/comply/audit/page.tsx
@@ -1,0 +1,8 @@
+export default function ComplyAudit() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl mb-4">Audit</h1>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/comply/overview/page.tsx
+++ b/src/app/org/[orgId]/comply/overview/page.tsx
@@ -1,0 +1,15 @@
+import { request } from "@/lib/client";
+import ReportsList from "@/components/comply/ReportsList";
+
+export default async function ComplyOverview({ params:{orgId} }:{params:{orgId:string}}) {
+  const files = await request(`/org/${orgId}/reports?type=csrd`, "get", { orgId });
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl">CSRD / ESRS Reports</h1>
+        <ReportsList.GenerateButton orgId={orgId} />
+      </div>
+      <ReportsList files={files as any} />
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/comply/page.tsx
+++ b/src/app/org/[orgId]/comply/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ComplyIndex({ params:{orgId} }:{params:{orgId:string}}) {
+  redirect(`/org/${orgId}/comply/overview`);
+}

--- a/src/app/org/[orgId]/comply/templates/page.tsx
+++ b/src/app/org/[orgId]/comply/templates/page.tsx
@@ -1,0 +1,8 @@
+export default function ComplyTemplates() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl mb-4">Templates</h1>
+      <p>Coming soon.</p>
+    </div>
+  );
+}

--- a/src/components/alerts/AlertTable.tsx
+++ b/src/components/alerts/AlertTable.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+import { VirtualTable } from "@/components/ui/VirtualTable";
+import { useApi } from "@/lib/hooks";
+
+export default function AlertTable({ initial = [], orgId }: { initial?: any[]; orgId: string }) {
+  const [status, setStatus] = useState("open");
+  const { data } = useApi<any[]>(`/org/${orgId}/alerts?status=${status}`, { refresh: 10000 });
+  const alerts = data ?? initial;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 text-sm">
+        {['open','snoozed','resolved'].map(s => (
+          <button
+            key={s}
+            onClick={() => setStatus(s)}
+            className={`rounded px-2 py-1 ${status===s ? 'bg-blue-600 text-white' : 'bg-neutral-700 text-white/60'}`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      <VirtualTable
+        items={alerts}
+        rowHeight={36}
+        renderRow={(a) => (
+          <div className="grid grid-cols-[160px_1fr_80px] gap-2 px-2 text-sm" key={a.id}>
+            <span>{new Date(a.time).toLocaleString()}</span>
+            <span>{a.msg}</span>
+            <span className="text-right">{a.status}</span>
+          </div>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/comply/ReportsList.tsx
+++ b/src/components/comply/ReportsList.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import { Button } from "@/components/ui/Button";
+import { VirtualTable } from "@/components/ui/VirtualTable";
+
+const ReportWizard = dynamic(() => import("./ReportWizard").then(m => m.ReportWizard), { ssr: false });
+
+export default function ReportsList({ files }: { files: any[] }) {
+  return (
+    <VirtualTable
+      items={files ?? []}
+      renderRow={(f) => (
+        <div className="flex justify-between px-2" key={f.id}>
+          <span>{f.period}</span>
+          <a href={f.link} className="underline">Download</a>
+        </div>
+      )}
+    />
+  );
+}
+
+ReportsList.GenerateButton = function({ orgId }: { orgId: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Generate</Button>
+      {open && (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/50" onClick={() => setOpen(false)}>
+          <div className="bg-white p-4" onClick={e => e.stopPropagation()}>
+            <ReportWizard />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -60,6 +60,20 @@ const FIXTURES: Record<string, unknown> = {
   "/org/{orgId}/kpi": [
     { id: "energy",    label: "kWh",  value: 42_000 },
     { id: "emissions", label: "tCO₂", value: 123.4 }
+  ],
+
+  "/org/{orgId}/projects": [
+    { id: "p1", name: "GreenShop" }
+  ],
+
+  "/org/{orgId}/projects/{projectId}/summary": { id: "p1", name: "GreenShop" },
+
+  "/org/{orgId}/alerts": [
+    { id: 1, time: Date.now(), source: "budget", msg: "Forecast overshoot", status: "open" }
+  ],
+
+  "/org/{orgId}/reports?type=csrd": [
+    { id: "r1", period: "FY2026", link: "#" }
   ]
 
   

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import useSWR from 'swr'
 import { request } from './request'
 
 export function useUser(id: string) {
@@ -6,4 +7,10 @@ export function useUser(id: string) {
     queryKey: ['user', id],
     queryFn: () => request('/user/{id}', 'get', { id }),
   })
+}
+
+export function useApi<T>(path: string, opts?: { refresh: number }) {
+  return useSWR<T>(path, () => request(path as any, 'get', {}), {
+    refreshInterval: opts?.refresh,
+  });
 }

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -3,6 +3,8 @@ export type NavItem = { href: string; label: string; icon: string; flag?: string
 export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   developer: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
+    { href: "/plugins", label: "Plugins", icon: "🔌" },
+    { href: "/projects", label: "Projects", icon: "🗂" },
     { href: "/router", label: "Router", icon: "🗺", flag: "router" },
     { href: "/pulse", label: "Pulse", icon: "💓", flag: "pulse" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
@@ -14,14 +16,16 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
     { href: "/budget", label: "Budget", icon: "💶", flag: "budget" },
-    { href: "/offsets", label: "Offsets", icon: "🌿" }
+    { href: "/offsets", label: "Offsets", icon: "🌿" },
+    { href: "/alerts", label: "Alerts", icon: "🚨" }
   ],
   sustainability: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
     { href: "/reports", label: "Reports", icon: "📄" },
     { href: "/ecolabel", label: "EcoLabel", icon: "🏷" },
-    { href: "/offsets", label: "Offsets", icon: "🌳" }
+    { href: "/offsets", label: "Offsets", icon: "🌳" },
+    { href: "/comply", label: "Comply", icon: "📄", flag: "comply" }
   ],
   admin: [{ href: "/settings", label: "Settings", icon: "⚙️" }]
 } as const;


### PR DESCRIPTION
## Summary
- add new CarbonComply pages and redirect
- create alert table and reports list components
- mock API routes for projects, alerts, reports
- expose useApi helper and expand fixtures
- extend navigation items for new sections

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: missing script)*
- `pnpm exec tsc --noEmit` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c3e869c1c83229f526fd9517a723c