### PR TITLE
Add widgets and stub pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "./globals.css";
 import { Inter }        from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Providers }     from "./providers";
-import { Shell }         from "@/components/Shell";
+import Shell from "@/components/Shell";
 import { OrgProvider }   from "@/contexts/OrgContext";
 
 const inter = Inter({ subsets:["latin"], variable:"--font-inter" });

--- a/src/app/org/[orgId]/budget/overview/page.tsx
+++ b/src/app/org/[orgId]/budget/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Budget overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/comply/audit/page.tsx
+++ b/src/app/org/[orgId]/comply/audit/page.tsx
@@ -1,8 +1,3 @@
-export default function ComplyAudit() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl mb-4">Audit</h1>
-      <p>Coming soon.</p>
-    </div>
-  );
+export default function AuditTrail() {
+  return <div className="p-6">Audit trail view coming soon…</div>;
 }

--- a/src/app/org/[orgId]/comply/overview/page.tsx
+++ b/src/app/org/[orgId]/comply/overview/page.tsx
@@ -1,15 +1,32 @@
 import { request } from "@/lib/client";
-import ReportsList from "@/components/comply/ReportsList";
+import DownloadDropdown from "@/components/widgets/DownloadDropdown";
 
-export default async function ComplyOverview({ params:{orgId} }:{params:{orgId:string}}) {
-  const files = await request(`/org/${orgId}/reports?type=csrd`, "get", { orgId });
+export const revalidate = 60;
+
+export default async function ComplyOverview({
+  params: { orgId },
+}: {
+  params: { orgId: string };
+}) {
+  const files = await request<any[]>(`/org/${orgId}/reports?type=csrd`);
   return (
     <div className="p-6">
-      <div className="mb-6 flex items-center justify-between">
+      <div className="flex justify-between mb-6">
         <h1 className="text-2xl">CSRD / ESRS Reports</h1>
-        <ReportsList.GenerateButton orgId={orgId} />
+        <button className="border px-3 py-1">Generate new</button>
       </div>
-      <ReportsList files={files as any} />
+      <ul>
+        {files.map((f) => (
+          <li key={f.id} className="flex items-center gap-4 mb-2">
+            <span>{f.period}</span>
+            <DownloadDropdown
+              onSelect={(fmt) => {
+                window.location.href = `/api/reports/${f.id}.${fmt}`;
+              }}
+            />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/app/org/[orgId]/comply/templates/page.tsx
+++ b/src/app/org/[orgId]/comply/templates/page.tsx
@@ -1,8 +1,3 @@
-export default function ComplyTemplates() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl mb-4">Templates</h1>
-      <p>Coming soon.</p>
-    </div>
-  );
+export default function Templates() {
+  return <div className="p-6">Template manager coming soon…</div>;
 }

--- a/src/app/org/[orgId]/ecolabel/overview/page.tsx
+++ b/src/app/org/[orgId]/ecolabel/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Ecolabel overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/greendev/overview/page.tsx
+++ b/src/app/org/[orgId]/greendev/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Greendev overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/iac-advisor/overview/page.tsx
+++ b/src/app/org/[orgId]/iac-advisor/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function IacOverview() {
+  return <div className="p-6">IaC Advisor — Pull-request feed</div>;
+}

--- a/src/app/org/[orgId]/iac-advisor/rules/page.tsx
+++ b/src/app/org/[orgId]/iac-advisor/rules/page.tsx
@@ -1,0 +1,3 @@
+export default function IacRules() {
+  return <div className="p-6">IaC Advisor rules coming soon…</div>;
+}

--- a/src/app/org/[orgId]/iac-advisor/settings/page.tsx
+++ b/src/app/org/[orgId]/iac-advisor/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function IacSettings() {
+  return <div className="p-6">IaC Advisor settings coming soon…</div>;
+}

--- a/src/app/org/[orgId]/offsets/overview/page.tsx
+++ b/src/app/org/[orgId]/offsets/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Offsets overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectLedger() {
+  return <div className="p-6">Project-scoped ledger coming soon…</div>;
+}

--- a/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectPlugins() {
+  return <div className="p-6">Project plugins coming soon…</div>;
+}

--- a/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectTeam() {
+  return <div className="p-6">Project team coming soon…</div>;
+}

--- a/src/app/org/[orgId]/pulse/overview/page.tsx
+++ b/src/app/org/[orgId]/pulse/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Pulse overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/router/overview/page.tsx
+++ b/src/app/org/[orgId]/router/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Router overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/scheduler/overview/page.tsx
+++ b/src/app/org/[orgId]/scheduler/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function PluginOverview() {
+  return <div className="p-6">Scheduler overview coming soon…</div>;
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { Component, ErrorInfo, ReactNode } from "react";
+
+export default class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error?: Error }
+> {
+  state = { error: undefined as Error | undefined };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(error, info);
+  }
+
+  render() {
+    if (this.state.error)
+      return (
+        <div className="p-6">
+          <h1 className="text-xl mb-2">Something went wrong</h1>
+          <p className="mb-4 text-sm">{this.state.error.message}</p>
+          <button className="underline" onClick={() => location.reload()}>
+            Reload page
+          </button>
+        </div>
+      );
+    return this.props.children;
+  }
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,15 +1,17 @@
-"use client";
-import { Sidebar }   from "./Sidebar";
-import { UserButton } from "@clerk/nextjs";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import Sidebar from "@/components/Sidebar";
+import Topbar from "@/components/navigation/Topbar";
 
-export function Shell({ children }: { children: React.ReactNode }) {
+export default function Shell({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto p-6">{children}</main>
-      <div className="fixed bottom-4 right-6 z-10">
-        <UserButton afterSignOutUrl="/" />
-      </div>
+      <section className="flex-1 flex flex-col">
+        <Topbar />
+        <ErrorBoundary>
+          <main className="flex-1 overflow-auto">{children}</main>
+        </ErrorBoundary>
+      </section>
     </div>
   );
 }

--- a/src/components/alerts/AlertTable.tsx
+++ b/src/components/alerts/AlertTable.tsx
@@ -1,34 +1,50 @@
 "use client";
-import { useState } from "react";
-import { VirtualTable } from "@/components/ui/VirtualTable";
-import { useApi } from "@/lib/hooks";
 
-export default function AlertTable({ initial = [], orgId }: { initial?: any[]; orgId: string }) {
-  const [status, setStatus] = useState("open");
-  const { data } = useApi<any[]>(`/org/${orgId}/alerts?status=${status}`, { refresh: 10000 });
-  const alerts = data ?? initial;
+import { useApi } from "@/lib/hooks";
+import VirtualTable from "@/components/tables/VirtualTable";
+import { useState } from "react";
+
+export default function AlertTable({
+  initial,
+  orgId,
+}: {
+  initial: any[];
+  orgId: string;
+}) {
+  const [filter, setFilter] = useState<"all" | "open">("all");
+  const { data } = useApi<any[]>(
+    `/org/${orgId}/alerts?filter=${filter}`,
+    { refresh: 5000 }
+  );
+
+  const rows = data ?? initial;
 
   return (
-    <div className="space-y-4">
-      <div className="flex gap-2 text-sm">
-        {['open','snoozed','resolved'].map(s => (
-          <button
-            key={s}
-            onClick={() => setStatus(s)}
-            className={`rounded px-2 py-1 ${status===s ? 'bg-blue-600 text-white' : 'bg-neutral-700 text-white/60'}`}
-          >
-            {s}
-          </button>
-        ))}
+    <div>
+      <div className="mb-2">
+        <button
+          className={`mr-2 ${filter === "all" ? "font-semibold" : ""}`}
+          onClick={() => setFilter("all")}
+        >
+          All
+        </button>
+        <button
+          className={filter === "open" ? "font-semibold" : ""}
+          onClick={() => setFilter("open")}
+        >
+          Open
+        </button>
       </div>
+
       <VirtualTable
-        items={alerts}
+        items={rows}
         rowHeight={36}
-        renderRow={(a) => (
-          <div className="grid grid-cols-[160px_1fr_80px] gap-2 px-2 text-sm" key={a.id}>
-            <span>{new Date(a.time).toLocaleString()}</span>
-            <span>{a.msg}</span>
-            <span className="text-right">{a.status}</span>
+        renderRow={(item) => (
+          <div className="flex w-full">
+            <div className="w-40 px-2">{new Date(item.time).toLocaleString()}</div>
+            <div className="w-24 px-2">{item.source}</div>
+            <div className="flex-1 px-2">{item.msg}</div>
+            <div className="w-24 px-2">{item.status}</div>
           </div>
         )}
       />

--- a/src/components/navigation/Topbar.tsx
+++ b/src/components/navigation/Topbar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useOrgStore } from "@/lib/stores";
+import Link from "next/link";
+
+export default function Topbar() {
+  const { orgId } = useOrgStore();
+
+  return (
+    <header className="h-12 border-b flex items-center justify-between px-4">
+      <div className="flex items-center gap-4">
+        <select className="border rounded text-sm px-2 py-1">
+          <option>{orgId}</option>
+          {/* TODO: dynamic org list */}
+        </select>
+        <button className="border rounded px-3 py-1 text-sm">Create…</button>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <Link href={`/org/${orgId}/alerts`} className="text-xl">
+          🔔
+        </Link>
+        <div className="w-8 h-8 rounded-full bg-gray-300" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/tables/VirtualTable.tsx
+++ b/src/components/tables/VirtualTable.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { useCallback } from 'react';
+
+/* ---------- public types ---------- */
+
+export type RowRendererProps = {
+  index: number;
+  style: React.CSSProperties;
+};
+
+export interface VirtualTableProps<T> {
+  /** Array of rows; defaults to [] so .length is always defined */
+  items?: T[];
+  /** Function that returns JSX for each row */
+  renderRow: (item: T, ctx: RowRendererProps) => React.ReactNode;
+
+  /* Optional tweaks */
+  height?: number;        // px – default 400
+  rowHeight?: number;     // px – default 32
+  overscanCount?: number; // extra rows to render ahead of scroll – default 5
+}
+
+/* ---------- component ---------- */
+
+export function VirtualTable<T>({
+  items = [],               // <-- safe default
+  renderRow,
+  height = 400,
+  rowHeight = 32,
+  overscanCount = 5,
+}: VirtualTableProps<T>) {
+  /* Memoise row renderer so React-Window can recycle DOM nodes efficiently */
+  const Row = useCallback(
+    ({ index, style }: ListChildComponentProps) =>
+      renderRow(items[index], { index, style }),
+    [items, renderRow],
+  );
+
+  return (
+    <AutoSizer disableHeight>
+      {({ width }) =>
+        items.length === 0 ? (
+          <div
+            style={{
+              width,
+              height,
+              lineHeight: `${height}px`,
+              textAlign: 'center',
+              color: '#9ca3af',          /* Tailwind neutral-400 */
+              fontSize: 14,
+            }}
+          >
+            No data
+          </div>
+        ) : (
+          <List
+            width={width}
+            height={height}
+            itemCount={items.length}
+            itemSize={rowHeight}
+            overscanCount={overscanCount}
+          >
+            {Row}
+          </List>
+        )
+      }
+    </AutoSizer>
+  );
+}

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
+
+export default function Tabs({
+  tabs,
+}: {
+  tabs: { id: string; label: string; href: string }[];
+}) {
+  const path = usePathname();
+  return (
+    <nav className="flex gap-4 border-b mb-4">
+      {tabs.map(({ id, label, href }) => (
+        <Link
+          key={id}
+          href={href}
+          className={clsx(
+            "py-2 text-sm",
+            path === href
+              ? "border-b-2 border-blue-500 font-medium"
+              : "text-gray-500"
+          )}
+        >
+          {label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/widgets/CarbonBadge.tsx
+++ b/src/components/widgets/CarbonBadge.tsx
@@ -1,0 +1,7 @@
+export default function CarbonBadge({ value }: { value: number }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs">
+      🌿 {value.toFixed(1)} kg CO₂
+    </span>
+  );
+}

--- a/src/components/widgets/DownloadDropdown.tsx
+++ b/src/components/widgets/DownloadDropdown.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useClickAway } from "react-use";
+
+export default function DownloadDropdown({
+  onSelect,
+}: {
+  onSelect: (fmt: "csv" | "xlsx" | "pdf") => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickAway(ref, () => setOpen(false));
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        className="border rounded px-3 py-1 text-sm"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Download ▼
+      </button>
+      {open && (
+        <ul className="absolute right-0 mt-1 w-28 border bg-white shadow">
+          {(["csv", "xlsx", "pdf"] as const).map((fmt) => (
+            <li key={fmt}>
+              <button
+                className="block w-full px-3 py-1 text-left text-sm hover:bg-gray-100"
+                onClick={() => {
+                  onSelect(fmt);
+                  setOpen(false);
+                }}
+              >
+                {fmt.toUpperCase()}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/widgets/LiveStreamToggle.tsx
+++ b/src/components/widgets/LiveStreamToggle.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useState } from "react";
+
+export default function LiveStreamToggle({
+  enabled,
+  onToggle,
+}: {
+  enabled: boolean;
+  onToggle: (v: boolean) => void;
+}) {
+  const [state, setState] = useState(enabled);
+  return (
+    <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={state}
+        onChange={(e) => {
+          setState(e.target.checked);
+          onToggle(e.target.checked);
+        }}
+      />
+      Live stream
+    </label>
+  );
+}

--- a/src/components/widgets/TimeRangePicker.tsx
+++ b/src/components/widgets/TimeRangePicker.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+export type Range = "7d" | "30d" | "custom";
+
+export default function TimeRangePicker({
+  onChange,
+}: {
+  onChange: (r: Range, custom?: [Date, Date]) => void;
+}) {
+  const [range, setRange] = useState<Range>("7d");
+
+  return (
+    <div className="inline-flex border rounded overflow-hidden">
+      {(["7d", "30d", "custom"] as Range[]).map((r) => (
+        <button
+          key={r}
+          className={`px-3 py-1 text-sm ${
+            range === r ? "bg-gray-200 font-medium" : ""
+          }`}
+          onClick={() => {
+            setRange(r);
+            onChange(r);
+          }}
+        >
+          {r === "custom" ? "Custom" : r}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,16 +1,8 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import useSWR from 'swr'
-import { request } from './request'
+import useSWR from "swr";
+import { request } from "./client";
 
-export function useUser(id: string) {
-  return useQuery({
-    queryKey: ['user', id],
-    queryFn: () => request('/user/{id}', 'get', { id }),
-  })
-}
-
-export function useApi<T>(path: string, opts?: { refresh: number }) {
-  return useSWR<T>(path, () => request(path as any, 'get', {}), {
+export function useApi<T>(path: string, opts?: { refresh?: number }) {
+  return useSWR<T>(path, () => request<T>(path), {
     refreshInterval: opts?.refresh,
   });
 }

--- a/src/lib/mocks/handlers.ts
+++ b/src/lib/mocks/handlers.ts
@@ -1,0 +1,47 @@
+import { rest } from "msw";
+
+export const handlers = [
+  /* existing … */
+
+  // Projects
+  rest.get("/api/org/:orgId/projects", (_, res, ctx) =>
+    res(
+      ctx.json([
+        { id: "proj1", name: "GreenShop" },
+        { id: "proj2", name: "EcoAPI" },
+      ])
+    )
+  ),
+  rest.get("/api/org/:orgId/projects/:projectId/summary", (req, res, ctx) =>
+    res(ctx.json({ id: req.params.projectId, name: "GreenShop" }))
+  ),
+
+  // Alerts
+  rest.get("/api/org/:orgId/alerts", (_, res, ctx) =>
+    res(
+      ctx.json([
+        {
+          id: 1,
+          time: Date.now(),
+          source: "budget",
+          msg: "Forecast overshoot",
+          status: "open",
+        },
+      ])
+    )
+  ),
+
+  // Reports
+  rest.get("/api/org/:orgId/reports", (req, res, ctx) =>
+    res(
+      ctx.json([
+        {
+          id: "r1",
+          period: "FY2026",
+          link: "#",
+          type: req.url.searchParams.get("type"),
+        },
+      ])
+    )
+  ),
+];

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -2,15 +2,17 @@ export type NavItem = { href: string; label: string; icon: string; flag?: string
 
 export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   developer: [
-    { href: "/dashboard", label: "Dashboard", icon: "📊" },
-    { href: "/plugins", label: "Plugins", icon: "🔌" },
-    { href: "/projects", label: "Projects", icon: "🗂" },
+    { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
+    { href: "/plugins", label: "Plugins", icon: "plug" },
+    { href: "/projects", label: "Projects", icon: "stack" },
+    { href: "/alerts", label: "Alerts", icon: "alert" },
     { href: "/router", label: "Router", icon: "🗺", flag: "router" },
     { href: "/pulse", label: "Pulse", icon: "💓", flag: "pulse" },
     { href: "/ledger", label: "Ledger", icon: "📜" },
     { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" },
     { href: "/iac-advisor", label: "IaC Advisor", icon: "🛠", flag: "iac-advisor" },
-    { href: "/greendev", label: "GreenDev Bot", icon: "🤖", flag: "greendev" }
+    { href: "/greendev", label: "GreenDev Bot", icon: "🤖", flag: "greendev" },
+    { href: "/comply", label: "Comply", icon: "report", flag: "comply" }
   ],
   finops: [
     { href: "/dashboard", label: "Dashboard", icon: "📊" },


### PR DESCRIPTION
## Summary
- add widgets components
- add Topbar and ErrorBoundary
- wrap layout shell with Topbar and ErrorBoundary
- stub plugin overview pages and project subroutes
- update navigation and add MSW handlers
- create tabs component and update alerts table
- add Comply overview/templates/audit routes

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `pnpm test` *(fails: Missing script: test)*
- `pnpm exec tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c4e0ac5e08322b2f9c6de9b8ebcb5