### PR TITLE
Refactor dynamic route params

### DIFF
--- a/src/app/_admin/events/[eventId]/page.tsx
+++ b/src/app/_admin/events/[eventId]/page.tsx
@@ -7,7 +7,10 @@ import { toast } from 'sonner';
 const JsonViewer = dynamic(() => import('react-json-view'), { ssr: false });
 const DiffViewer = dynamic(() => import('react-json-view-diff'), { ssr: false });
 
-export default async function EventDetail({ params: { eventId } }: { params: { eventId: string } }) {
+export default async function EventDetail(
+  props: { params: { eventId: string } },
+) {
+  const { eventId } = props.params;
   const ev = await request(`/api/events/${eventId}`);
   if (!ev) notFound();
   const prev = (ev as any).prev ?? null;

--- a/src/app/org/[orgId]/alerts/page.tsx
+++ b/src/app/org/[orgId]/alerts/page.tsx
@@ -3,8 +3,10 @@ import AlertTable from "@/components/alerts/AlertTable"; // create if missing
 
 export const revalidate = 10;
 
-export default async function AlertsPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default async function AlertsPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   const data = await request(`/org/${orgId}/alerts`);
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/budget/page.tsx
+++ b/src/app/org/[orgId]/budget/page.tsx
@@ -3,8 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function BudgetPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function BudgetPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/comply/overview/page.tsx
+++ b/src/app/org/[orgId]/comply/overview/page.tsx
@@ -4,12 +4,12 @@ import ReportWizard from "@/components/comply/ReportWizard.client";
 
 export const revalidate = 60;
 
-export default async function ComplyOverview({
-  params,
-}: {
+export default async function ComplyOverview(
+  props: {
   params: { orgId: string };
-}) {
-  const { orgId } = params;
+  },
+) {
+  const { orgId } = props.params;
   const files = await request<any[]>(`/org/${orgId}/reports?type=csrd`);
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/comply/page.tsx
+++ b/src/app/org/[orgId]/comply/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
-export default function ComplyIndex({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function ComplyIndex(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   redirect(`/org/${orgId}/comply/overview`);
 }

--- a/src/app/org/[orgId]/dashboard/page.tsx
+++ b/src/app/org/[orgId]/dashboard/page.tsx
@@ -13,12 +13,12 @@ import { fetchCurrentBudget } from "@/lib/budget-api";
 import { ChartSkeleton } from "@/components/ui/ChartSkeleton";
 
 
-export default async function DashboardPage({
-  params,
-}: {
-  params: { orgId: string };
-}) {
-  const { orgId } = params;
+export default async function DashboardPage(
+  props: {
+    params: { orgId: string };
+  },
+) {
+  const { orgId } = props.params;
   // Server-side fetches (block render until resolved)
   const [kpis, alertCount, initialBudget] = await Promise.all([
     fetchKpis(orgId),

--- a/src/app/org/[orgId]/ecolabel/page.tsx
+++ b/src/app/org/[orgId]/ecolabel/page.tsx
@@ -1,8 +1,10 @@
 import { api } from "@/lib/api";
 import { AsyncStates } from "@/components/ui/AsyncStates";
 
-export default async function Page({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default async function Page(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   const data = await api.getEcoLabelStats(orgId);
   if (!data.length) return <AsyncStates state="empty" message="No page views yet." />;
   return (

--- a/src/app/org/[orgId]/greendev/page.tsx
+++ b/src/app/org/[orgId]/greendev/page.tsx
@@ -4,8 +4,10 @@ import ChatWindow from '@/components/greendev/ChatWindow';
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function Page({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function Page(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   if (!orgId) notFound();
   return (
     <Suspense fallback={<Loading />}>

--- a/src/app/org/[orgId]/layout.tsx
+++ b/src/app/org/[orgId]/layout.tsx
@@ -1,14 +1,14 @@
 import Shell from "@/components/Shell";
 import { getServerRole } from "@/lib/getRole.server";
 
-export default async function OrgLayout({
-  children,
-  params,
-}: {
-  children: React.ReactNode;
-  params: { orgId: string };
-}) {
+export default async function OrgLayout(
+  props: {
+    children: React.ReactNode;
+    params: { orgId: string };
+  },
+) {
   const role = await getServerRole();
+  const { children, params } = props;
   const { orgId } = params;
 
   return (

--- a/src/app/org/[orgId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/ledger/page.tsx
@@ -3,8 +3,10 @@ import LedgerTable from "@/components/ledger/Table";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function LedgerPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function LedgerPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/offsets/page.tsx
+++ b/src/app/org/[orgId]/offsets/page.tsx
@@ -7,8 +7,10 @@ import { Loading } from '@/components/Loading';
 
 export const revalidate = 60;
 
-export default function Page({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function Page(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/page.tsx
+++ b/src/app/org/[orgId]/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
-export default function OrgIndexPage({ params }: { params:{ orgId:string } }) {
-  redirect(`/org/${params.orgId}/dashboard`);
+export default function OrgIndexPage(
+  props: { params: { orgId: string } },
+) {
+  redirect(`/org/${props.params.orgId}/dashboard`);
 }

--- a/src/app/org/[orgId]/plugins/page.tsx
+++ b/src/app/org/[orgId]/plugins/page.tsx
@@ -2,8 +2,10 @@ import { PluginCards } from "@/components/dashboard/PluginCards.client";
 
 export const revalidate = 60;
 
-export default function PluginsHome({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function PluginsHome(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <div className="p-6">
       <h1 className="text-2xl mb-6">Available Plugins</h1>

--- a/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
@@ -6,12 +6,12 @@ import { useApi } from "@/lib/hooks";
 
 export const revalidate = 10;
 
-export default async function ProjectLedger({
-  params,
-}: {
+export default async function ProjectLedger(
+  props: {
   params: { orgId: string; projectId: string };
-}) {
-  const { orgId, projectId } = params;
+  },
+) {
+  const { orgId, projectId } = props.params;
   /* server fetch for first paint */
   const initial = await request<any[]>(
     `/org/${orgId}/projects/${projectId}/ledger`,

--- a/src/app/org/[orgId]/projects/[projectId]/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/page.tsx
@@ -2,10 +2,10 @@
 import { request } from "@/lib/client";
 import { Tabs } from "@/components/ui/Tabs";          // assume you have one
 
-export default async function ProjectPage({
-  params,
-}: {params:{orgId:string;projectId:string}}) {
-  const { orgId, projectId } = params;
+export default async function ProjectPage(
+  props: { params:{orgId:string;projectId:string} },
+) {
+  const { orgId, projectId } = props.params;
   const summary = await request(`/org/${orgId}/projects/${projectId}/summary`);
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
@@ -1,11 +1,11 @@
 import { request } from "@/lib/client";
 
-export default async function ProjectPlugins({
-  params,
-}: {
+export default async function ProjectPlugins(
+  props: {
   params: { orgId: string; projectId: string };
-}) {
-  const { orgId, projectId } = params;
+  },
+) {
+  const { orgId, projectId } = props.params;
   const plugins = await request<
     { slug: string; title: string; enabled: boolean }[]
   >(`/org/${orgId}/projects/${projectId}/plugins`);

--- a/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
@@ -1,11 +1,11 @@
 import { request } from "@/lib/client";
 
-export default async function ProjectTeam({
-  params,
-}: {
+export default async function ProjectTeam(
+  props: {
   params: { orgId: string; projectId: string };
-}) {
-  const { orgId, projectId } = params;
+  },
+) {
+  const { orgId, projectId } = props.params;
   const team = await request<{ id: string; name: string; role: string }[]>(
     `/org/${orgId}/projects/${projectId}/team`
   );

--- a/src/app/org/[orgId]/projects/page.tsx
+++ b/src/app/org/[orgId]/projects/page.tsx
@@ -2,8 +2,10 @@
 import { request } from "@/lib/client";
 import Link from "next/link";
 
-export default async function ProjectsPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default async function ProjectsPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   const projects = await request(`/org/${orgId}/projects`, "get", { orgId });
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/pulse/page.tsx
+++ b/src/app/org/[orgId]/pulse/page.tsx
@@ -3,8 +3,10 @@ import { fetchVendors } from "@/lib/vendor-api";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function Pulse({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function Pulse(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/router/page.tsx
+++ b/src/app/org/[orgId]/router/page.tsx
@@ -3,8 +3,10 @@ import { request }  from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function RouterPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function RouterPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/scheduler/page.tsx
+++ b/src/app/org/[orgId]/scheduler/page.tsx
@@ -3,8 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function SchedulerPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function SchedulerPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/settings/page.tsx
+++ b/src/app/org/[orgId]/settings/page.tsx
@@ -3,8 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function SettingsPage({ params }: { params: { orgId: string } }) {
-  const { orgId } = params;
+export default function SettingsPage(
+  props: { params: { orgId: string } },
+) {
+  const { orgId } = props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />


### PR DESCRIPTION
## Summary
- avoid destructuring params in page and layout signatures
- update all affected org pages and admin events page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2a214b5c8322a36e02c248efb627