### PR TITLE
Fix dynamic API rule

### DIFF
--- a/src/lib/getFetchInit.ts
+++ b/src/lib/getFetchInit.ts
@@ -1,0 +1,7 @@
+// ALWAYS call from inside another helper, never directly in <Page>
+export async function getFetchInit() {
+  const { headers } = await import("next/headers");
+  return {
+    headers: Object.fromEntries(headers()),
+  };
+}

--- a/src/lib/request.server.ts
+++ b/src/lib/request.server.ts
@@ -1,3 +1,5 @@
+import { getFetchInit } from './getFetchInit';
+
 const LOCAL_BASE =
   process.env.NEXT_PUBLIC_API_BASE ??
   (process.env.NODE_ENV === 'production'
@@ -21,9 +23,8 @@ export async function request<T = unknown>(
   /* ──  only when *actually* running on the server ─────────────── */
   let cookieHeaders: Record<string, string> = {};
   if (typeof window === 'undefined') {
-    const { headers } = await import('next/headers'); // ★ dynamic
-    const h = await headers();
-    cookieHeaders = Object.fromEntries(h);
+    const { headers: h } = await getFetchInit();
+    cookieHeaders = h;
   }
 
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- centralize dynamic header handling in a new `getFetchInit` helper
- use that helper inside `request.server.ts`

## Testing
- `npm run lint` *(fails: next not found)*
- `npx vitest run` *(fails: could not download vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685d32f0cb6483229896dd9482d4c89d