### PR TITLE
Fix Next 15 params

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-hot-toast": "^2.5.2",
     "react-leaflet": "^5.0.0",
     "react-markdown": "^10.1.0",
+    "react-use": "^17.4.0",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "recharts": "^3.0.0",

--- a/src/app/_admin/events/[eventId]/page.tsx
+++ b/src/app/_admin/events/[eventId]/page.tsx
@@ -8,9 +8,9 @@ const JsonViewer = dynamic(() => import('react-json-view'), { ssr: false });
 const DiffViewer = dynamic(() => import('react-json-view-diff'), { ssr: false });
 
 export default async function EventDetail(
-  props: { params: { eventId: string } },
+  props: { params: Promise<{ eventId: string }> },
 ) {
-  const { eventId } = props.params;
+  const { eventId } = await props.params;
   const ev = await request(`/api/events/${eventId}`);
   if (!ev) notFound();
   const prev = (ev as any).prev ?? null;

--- a/src/app/api/org/[orgId]/snapshot/route.ts
+++ b/src/app/api/org/[orgId]/snapshot/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    total: 18423,
+    totalTrend: Array.from({ length: 30 }, () => Math.random() * 20000),
+    co2: 32.4,
+    co2Trend: Array.from({ length: 30 }, () => Math.random() * 40),
+    topProject: {
+      name: "frontend-refactor",
+      trend: Array.from({ length: 30 }, () => Math.random() * 5000),
+    },
+  });
+}

--- a/src/app/org/[orgId]/alerts/page.tsx
+++ b/src/app/org/[orgId]/alerts/page.tsx
@@ -4,10 +4,10 @@ import AlertTable from "@/components/alerts/AlertTable"; // create if missing
 export const revalidate = 10;
 
 export default async function AlertsPage(
-  props: { params: { orgId: string } },
+  props: { params: Promise<{ orgId: string }> },
 ) {
   await Promise.resolve();
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   const data = await request(`/org/${orgId}/alerts`);
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/budget/page.tsx
+++ b/src/app/org/[orgId]/budget/page.tsx
@@ -3,10 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function BudgetPage(
-  props: { params: { orgId: string } },
+export default async function BudgetPage(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/comply/overview/page.tsx
+++ b/src/app/org/[orgId]/comply/overview/page.tsx
@@ -6,11 +6,11 @@ export const revalidate = 60;
 
 export default async function ComplyOverview(
   props: {
-  params: { orgId: string };
+  params: Promise<{ orgId: string }>;
   },
 ) {
   await Promise.resolve();
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   const files = await request<any[]>(`/org/${orgId}/reports?type=csrd`);
   const list = Array.isArray(files) ? files : [];
   return (

--- a/src/app/org/[orgId]/comply/page.tsx
+++ b/src/app/org/[orgId]/comply/page.tsx
@@ -1,8 +1,8 @@
 import { redirect } from "next/navigation";
 
-export default function ComplyIndex(
-  props: { params: { orgId: string } },
+export default async function ComplyIndex(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   redirect(`/org/${orgId}/comply/overview`);
 }

--- a/src/app/org/[orgId]/dashboard/page.tsx
+++ b/src/app/org/[orgId]/dashboard/page.tsx
@@ -13,11 +13,11 @@ import { ChartSkeleton } from "@/components/ui/ChartSkeleton";
 
 export default async function DashboardPage(
   props: {
-    params: { orgId: string };
+    params: Promise<{ orgId: string }>;
   },
 ) {
   await Promise.resolve();
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   // Server-side fetches (block render until resolved)
   const [alertCount] = await Promise.all([
     fetchAlertCount(orgId),

--- a/src/app/org/[orgId]/ecolabel/page.tsx
+++ b/src/app/org/[orgId]/ecolabel/page.tsx
@@ -2,10 +2,10 @@ import { api } from "@/lib/api";
 import { AsyncStates } from "@/components/ui/AsyncStates";
 
 export default async function Page(
-  props: { params: { orgId: string } },
+  props: { params: Promise<{ orgId: string }> },
 ) {
   await Promise.resolve();
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   const data = await api.getEcoLabelStats(orgId);
   const list = Array.isArray(data) ? data : [];
   if (!list.length) return <AsyncStates state="empty" message="No page views yet." />;

--- a/src/app/org/[orgId]/greendev/page.tsx
+++ b/src/app/org/[orgId]/greendev/page.tsx
@@ -4,10 +4,10 @@ import ChatWindow from '@/components/greendev/ChatWindow';
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function Page(
-  props: { params: { orgId: string } },
+export default async function Page(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   if (!orgId) notFound();
   return (
     <Suspense fallback={<Loading />}>

--- a/src/app/org/[orgId]/layout.tsx
+++ b/src/app/org/[orgId]/layout.tsx
@@ -6,10 +6,10 @@ export default async function OrgLayout({
   params,
 }: {
   children: React.ReactNode;
-  params: { orgId: string };
+  params: Promise<{ orgId: string }>;
 }) {
   /* 1️⃣  capture the dynamic segment immediately */
-  const { orgId } = params;        // ⬅️  NO await yet!
+  const { orgId } = await params;        // ⬅️  NO await yet!
 
   /* 2️⃣  now you’re free to await anything */
   const role = await getServerRole();

--- a/src/app/org/[orgId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/ledger/page.tsx
@@ -4,7 +4,8 @@ import LiveStreamToggle from "@/components/widgets/LiveStreamToggle";
 import DownloadDropdown from "@/components/widgets/DownloadDropdown";
 import LedgerTable from "@/components/ledger/Table";
 
-export default function LedgerPage({ params: { orgId } }) {
+export default async function LedgerPage({ params }: { params: Promise<{ orgId: string }> }) {
+  const { orgId } = await params;
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">

--- a/src/app/org/[orgId]/offsets/page.tsx
+++ b/src/app/org/[orgId]/offsets/page.tsx
@@ -7,10 +7,10 @@ import { Loading } from '@/components/Loading';
 
 export const revalidate = 60;
 
-export default function Page(
-  props: { params: { orgId: string } },
+export default async function Page(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/page.tsx
+++ b/src/app/org/[orgId]/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 
-export default function OrgIndexPage(
-  props: { params: { orgId: string } },
+export default async function OrgIndexPage(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  redirect(`/org/${props.params.orgId}/dashboard`);
+  const { orgId } = await props.params;
+  redirect(`/org/${orgId}/dashboard`);
 }

--- a/src/app/org/[orgId]/plugins/page.tsx
+++ b/src/app/org/[orgId]/plugins/page.tsx
@@ -2,10 +2,10 @@ import { PluginCards } from "@/components/dashboard/PluginCards.client";
 
 export const revalidate = 60;
 
-export default function PluginsHome(
-  props: { params: { orgId: string } },
+export default async function PluginsHome(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <div className="p-6">
       <h1 className="text-2xl mb-6">Available Plugins</h1>

--- a/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/ledger/page.tsx
@@ -8,11 +8,11 @@ export const revalidate = 10;
 
 export default async function ProjectLedger(
   props: {
-  params: { orgId: string; projectId: string };
+  params: Promise<{ orgId: string; projectId: string }>;
   },
 ) {
   await Promise.resolve();
-  const { orgId, projectId } = props.params;
+  const { orgId, projectId } = await props.params;
   /* server fetch for first paint */
   const initial = await request<any[]>(
     `/org/${orgId}/projects/${projectId}/ledger`,

--- a/src/app/org/[orgId]/projects/[projectId]/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/page.tsx
@@ -3,10 +3,10 @@ import { request } from "@/lib/client";
 import { Tabs } from "@/components/ui/Tabs";          // assume you have one
 
 export default async function ProjectPage(
-  props: { params:{orgId:string;projectId:string} },
+  props: { params: Promise<{orgId:string;projectId:string}> },
 ) {
   await Promise.resolve();
-  const { orgId, projectId } = props.params;
+  const { orgId, projectId } = await props.params;
   const summary = await request(`/org/${orgId}/projects/${projectId}/summary`);
   return (
     <div className="p-6">

--- a/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/plugins/page.tsx
@@ -2,11 +2,11 @@ import { request } from "@/lib/client";
 
 export default async function ProjectPlugins(
   props: {
-  params: { orgId: string; projectId: string };
+  params: Promise<{ orgId: string; projectId: string }>;
   },
 ) {
   await Promise.resolve();
-  const { orgId, projectId } = props.params;
+  const { orgId, projectId } = await props.params;
   const plugins = await request<
     { slug: string; title: string; enabled: boolean }[]
   >(`/org/${orgId}/projects/${projectId}/plugins`);

--- a/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
+++ b/src/app/org/[orgId]/projects/[projectId]/team/page.tsx
@@ -2,11 +2,11 @@ import { request } from "@/lib/client";
 
 export default async function ProjectTeam(
   props: {
-  params: { orgId: string; projectId: string };
+  params: Promise<{ orgId: string; projectId: string }>;
   },
 ) {
   await Promise.resolve();
-  const { orgId, projectId } = props.params;
+  const { orgId, projectId } = await props.params;
   const team = await request<{ id: string; name: string; role: string }[]>(
     `/org/${orgId}/projects/${projectId}/team`
   );

--- a/src/app/org/[orgId]/projects/page.tsx
+++ b/src/app/org/[orgId]/projects/page.tsx
@@ -3,10 +3,10 @@ import { request } from "@/lib/client";
 import Link from "next/link";
 
 export default async function ProjectsPage(
-  props: { params: { orgId: string } },
+  props: { params: Promise<{ orgId: string }> },
 ) {
   await Promise.resolve();
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   const projects = await request(`/org/${orgId}/projects`, "get", { orgId });
   const list = Array.isArray(projects) ? projects : [];
   return (

--- a/src/app/org/[orgId]/pulse/page.tsx
+++ b/src/app/org/[orgId]/pulse/page.tsx
@@ -3,10 +3,10 @@ import { fetchVendors } from "@/lib/vendor-api";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function Pulse(
-  props: { params: { orgId: string } },
+export default async function Pulse(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/router/page.tsx
+++ b/src/app/org/[orgId]/router/page.tsx
@@ -1,5 +1,6 @@
 import RouterClient from "./RouterClient";
 
-export default function RouterPage({ params:{orgId} }:{ params:{orgId:string} }) {
+export default async function RouterPage({ params }: { params: Promise<{orgId:string}> }) {
+  const { orgId } = await params;
   return <RouterClient orgId={orgId} />;
 }

--- a/src/app/org/[orgId]/scheduler/page.tsx
+++ b/src/app/org/[orgId]/scheduler/page.tsx
@@ -3,10 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function SchedulerPage(
-  props: { params: { orgId: string } },
+export default async function SchedulerPage(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/app/org/[orgId]/settings/page.tsx
+++ b/src/app/org/[orgId]/settings/page.tsx
@@ -3,10 +3,10 @@ import { request } from "@/lib/client";
 import { Suspense } from 'react';
 import { Loading } from '@/components/Loading';
 
-export default function SettingsPage(
-  props: { params: { orgId: string } },
+export default async function SettingsPage(
+  props: { params: Promise<{ orgId: string }> },
 ) {
-  const { orgId } = props.params;
+  const { orgId } = await props.params;
   return (
     <Suspense fallback={<Loading />}>
       <Content orgId={orgId} />

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -134,7 +134,7 @@ export async function request<
   let token: string | undefined;
   if (typeof window === "undefined") {
     const { cookies } = await import("next/headers");
-    const jar = cookies();
+    const jar = await cookies();
     token = jar.get("__session")?.value ?? jar.get("__Secure-session")?.value;
   }
   // (in the browser the cookie travels automatically)

--- a/src/lib/getFetchInit.ts
+++ b/src/lib/getFetchInit.ts
@@ -8,7 +8,7 @@ export async function getFetchInit() {
   /* second await – before first touch */
   await Promise.resolve();
 
-  const headerList = headers();             // 1st use (OK)
+  const headerList = await headers();             // 1st use (OK)
 
   /* third await – before **iterating again** inside Object.fromEntries */
   await Promise.resolve();


### PR DESCRIPTION
## Summary
- await `params`, `headers()` and `cookies()` per Next.js 15
- add missing `react-use` dependency
- create mock snapshot route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4cc868d0832295fccc2674ee8c1e