### PR TITLE
Sprint polish: icons, SSE hooks, routes

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@playwright/test";
+
+test("dashboard shows KPI cards & ledger filter", async ({ page }) => {
+  await page.goto("/org/1/dashboard");
+  await expect(page.locator("text=Total savings")).toBeVisible();
+  await page.locator("text=Project").click();
+  await page.locator("text=backend-api").click();
+  await expect(page.url()).toContain("project=backend-api");
+});

--- a/src/app/org/[orgId]/comply/audit/page.tsx
+++ b/src/app/org/[orgId]/comply/audit/page.tsx
@@ -1,3 +1,13 @@
-export default function AuditTrail() {
-  return <div className="p-6">Audit trail view coming soon…</div>;
+export default function AuditTrail({ params }: { params: { orgId: string } }) {
+  const { orgId } = params;
+  return (
+    <div className="p-6">
+      <button
+        className="btn"
+        onClick={() => window.open(`/api/org/${orgId}/comply/audit?format=xlsx`, "_blank")}
+      >
+        Export XLSX
+      </button>
+    </div>
+  );
 }

--- a/src/app/org/[orgId]/comply/templates/page.tsx
+++ b/src/app/org/[orgId]/comply/templates/page.tsx
@@ -1,3 +1,10 @@
-export default function Templates() {
-  return <div className="p-6">Template manager coming soon…</div>;
+import TemplateManager from "@/components/comply/TemplateManager";
+
+export default function Templates({ params }: { params: { orgId: string } }) {
+  const { orgId } = params;
+  return (
+    <div className="p-6">
+      <TemplateManager orgId={orgId} />
+    </div>
+  );
 }

--- a/src/app/org/[orgId]/ecolabel/experiments/page.tsx
+++ b/src/app/org/[orgId]/ecolabel/experiments/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperimentsPage() {
+  return <div className="p-6">Experiments coming soon…</div>;
+}

--- a/src/app/org/[orgId]/ecolabel/layout.tsx
+++ b/src/app/org/[orgId]/ecolabel/layout.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+export default function RouterLayout({ children }) {
+  return (
+    <div className="space-y-6">
+      <nav className="tabs">
+        <Link href="./overview">Overview</Link>
+        <Link href="./experiments">Experiments</Link>
+        <Link href="./logs">Logs</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/ecolabel/logs/page.tsx
+++ b/src/app/org/[orgId]/ecolabel/logs/page.tsx
@@ -1,0 +1,3 @@
+export default function LogsPage() {
+  return <div className="p-6">Logs coming soon…</div>;
+}

--- a/src/app/org/[orgId]/ledger/page.tsx
+++ b/src/app/org/[orgId]/ledger/page.tsx
@@ -3,22 +3,37 @@ import BalanceTrendChart from "@/components/ledger/BalanceTrendChart";
 import LiveStreamToggle from "@/components/widgets/LiveStreamToggle";
 import DownloadDropdown from "@/components/widgets/DownloadDropdown";
 import LedgerTable from "@/components/ledger/Table";
+import { fetchLedger } from "@/lib/ledger-api";
 
 export default async function LedgerPage({ params }: { params: Promise<{ orgId: string }> }) {
   const { orgId } = await params;
+  const initialRows = await fetchLedger(orgId, 50);
+  return <ClientPage orgId={orgId} initialRows={initialRows} />;
+}
+
+("use client");
+import { useState } from "react";
+import TimeRangePicker, { Range } from "@/components/widgets/TimeRangePicker";
+import CarbonBadge from "@/components/widgets/CarbonBadge";
+
+function ClientPage({ orgId, initialRows }: { orgId: string; initialRows: any[] }) {
+  const [live, setLive] = useState(false);
+  const [range, setRange] = useState<Range>("7d");
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <FilterBar orgId={orgId} />
-        <div className="flex gap-2">
-          <LiveStreamToggle scope="ledger" />
+        <div className="flex items-center gap-4">
+          <TimeRangePicker value={range} onChange={setRange} />
+          {range && <CarbonBadge orgId={orgId} range={range} />}
+          <LiveStreamToggle enabled={live} onToggle={setLive} />
           <DownloadDropdown endpoint={`/api/org/${orgId}/ledger/export`} />
         </div>
       </div>
 
       <BalanceTrendChart orgId={orgId} />
 
-      <LedgerTable orgId={orgId} />
+      <LedgerTable orgId={orgId} initialRows={initialRows} live={live} />
     </div>
   );
 }

--- a/src/app/org/[orgId]/offset-sync/experiments/page.tsx
+++ b/src/app/org/[orgId]/offset-sync/experiments/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperimentsPage() {
+  return <div className="p-6">Experiments coming soon…</div>;
+}

--- a/src/app/org/[orgId]/offset-sync/layout.tsx
+++ b/src/app/org/[orgId]/offset-sync/layout.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+export default function RouterLayout({ children }) {
+  return (
+    <div className="space-y-6">
+      <nav className="tabs">
+        <Link href="./overview">Overview</Link>
+        <Link href="./experiments">Experiments</Link>
+        <Link href="./logs">Logs</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/offset-sync/logs/page.tsx
+++ b/src/app/org/[orgId]/offset-sync/logs/page.tsx
@@ -1,0 +1,3 @@
+export default function LogsPage() {
+  return <div className="p-6">Logs coming soon…</div>;
+}

--- a/src/app/org/[orgId]/offset-sync/overview/page.tsx
+++ b/src/app/org/[orgId]/offset-sync/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function OverviewPage() {
+  return <div className="p-6">Overview coming soon…</div>;
+}

--- a/src/app/org/[orgId]/pulse/experiments/page.tsx
+++ b/src/app/org/[orgId]/pulse/experiments/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperimentsPage() {
+  return <div className="p-6">Experiments coming soon…</div>;
+}

--- a/src/app/org/[orgId]/pulse/layout.tsx
+++ b/src/app/org/[orgId]/pulse/layout.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+export default function PulseLayout({ children }) {
+  return (
+    <div className="space-y-6">
+      <nav className="tabs">
+        <Link href="./overview">Overview</Link>
+        <Link href="./experiments">Experiments</Link>
+        <Link href="./logs">Logs</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/pulse/logs/page.tsx
+++ b/src/app/org/[orgId]/pulse/logs/page.tsx
@@ -1,0 +1,3 @@
+export default function LogsPage() {
+  return <div className="p-6">Logs coming soon…</div>;
+}

--- a/src/app/org/[orgId]/router/experiments/page.tsx
+++ b/src/app/org/[orgId]/router/experiments/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperimentsPage() {
+  return <div className="p-6">Experiments coming soon…</div>;
+}

--- a/src/app/org/[orgId]/router/layout.tsx
+++ b/src/app/org/[orgId]/router/layout.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+export default function RouterLayout({ children }) {
+  return (
+    <div className="space-y-6">
+      <nav className="tabs">
+        <Link href="./overview">Overview</Link>
+        <Link href="./experiments">Experiments</Link>
+        <Link href="./logs">Logs</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/router/logs/page.tsx
+++ b/src/app/org/[orgId]/router/logs/page.tsx
@@ -1,0 +1,3 @@
+export default function LogsPage() {
+  return <div className="p-6">Logs coming soon…</div>;
+}

--- a/src/app/org/[orgId]/scheduler/experiments/page.tsx
+++ b/src/app/org/[orgId]/scheduler/experiments/page.tsx
@@ -1,0 +1,3 @@
+export default function ExperimentsPage() {
+  return <div className="p-6">Experiments coming soon…</div>;
+}

--- a/src/app/org/[orgId]/scheduler/layout.tsx
+++ b/src/app/org/[orgId]/scheduler/layout.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+export default function RouterLayout({ children }) {
+  return (
+    <div className="space-y-6">
+      <nav className="tabs">
+        <Link href="./overview">Overview</Link>
+        <Link href="./experiments">Experiments</Link>
+        <Link href="./logs">Logs</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/org/[orgId]/scheduler/logs/page.tsx
+++ b/src/app/org/[orgId]/scheduler/logs/page.tsx
@@ -1,0 +1,3 @@
+export default function LogsPage() {
+  return <div className="p-6">Logs coming soon…</div>;
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -19,6 +19,8 @@
 "use client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { Toaster } from "sonner";
+import "@/lib/i18n";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [client] = useState(() => new QueryClient());
@@ -32,5 +34,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  return (
+    <>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      {/* GLOBAL toast root  */}
+      <Toaster richColors position="top-right" />
+    </>
+  );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import { NAV_BY_ROLE } from "@/lib/nav";
 import { useOrgStore } from "@/lib/stores";
 import { useFlags } from "@/lib/useFlags";
+import { Icons } from "@/components/ui/Icons";
 
 export default function Sidebar({ role }: { role: string }) {
   const { orgId } = useOrgStore();
@@ -18,19 +19,23 @@ export default function Sidebar({ role }: { role: string }) {
   return (
     <aside className="w-56 border-r">
       <ul>
-        {items.map(({ href, label }) => (
-          <li key={label}>
-            <Link
-              href={`/org/${orgId}${href}`}
-              className={clsx(
-                "block px-4 py-2",
-                path?.startsWith(`/org/${orgId}${href}`) && "font-semibold"
-              )}
-            >
-              {label}
-            </Link>
-          </li>
-        ))}
+        {items.map((item) => {
+          const Icon = Icons[item.icon];
+          return (
+            <li key={item.label}>
+              <Link
+                href={`/org/${orgId}${item.href}`}
+                className={clsx(
+                  "block px-4 py-2 flex items-center gap-2",
+                  path?.startsWith(`/org/${orgId}${item.href}`) && "font-semibold"
+                )}
+              >
+                {Icon && <Icon className="h-4 w-4" />}
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </aside>
   );

--- a/src/components/comply/TemplateManager.tsx
+++ b/src/components/comply/TemplateManager.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useState } from "react";
+import { toastError } from "@/lib/toast";
+
+export default function TemplateManager({ orgId }: { orgId: string }) {
+  const [file, setFile] = useState<File | null>(null);
+  const upload = async () => {
+    if (!file) return;
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      await fetch(`/api/org/${orgId}/comply/templates`, { method: "POST", body: fd });
+    } catch (e) { toastError("Upload failed"); }
+  };
+  return (
+    <div>
+      <input type="file" accept=".xlsx" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+      <button onClick={upload} className="btn-primary">Upload</button>
+    </div>
+  );
+}

--- a/src/components/navigation/AvatarMenu.tsx
+++ b/src/components/navigation/AvatarMenu.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { Menu } from "@headlessui/react";
+import i18n from "@/lib/i18n";
+
+export default function AvatarMenu() {
+  return (
+    <Menu as="div" className="relative">
+      <Menu.Button className="w-8 h-8 rounded-full bg-gray-300" />
+      <Menu.Items className="absolute right-0 mt-2 rounded bg-white shadow">
+        <Menu.Item onSelect={() => i18n.changeLanguage("en")}>English</Menu.Item>
+        <Menu.Item onSelect={() => i18n.changeLanguage("ar")}>العربية</Menu.Item>
+      </Menu.Items>
+    </Menu>
+  );
+}

--- a/src/components/navigation/Topbar.tsx
+++ b/src/components/navigation/Topbar.tsx
@@ -1,26 +1,25 @@
 "use client";
 
 import { useOrgStore } from "@/lib/stores";
-import Link from "next/link";
+import OrgSwitcher from "@/components/org/OrgSwitcher";
+import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/Dialog";
+import QuickActions from "@/components/dashboard/QuickActions";
+import AvatarMenu from "@/components/navigation/AvatarMenu";
 
 export default function Topbar() {
   const { orgId } = useOrgStore();
 
   return (
-    <header className="h-12 border-b flex items-center justify-between px-4">
+    <header className="flex items-center justify-between bg-white p-4 shadow">
+      <OrgSwitcher currentId={orgId} />
       <div className="flex items-center gap-4">
-        <select className="border rounded text-sm px-2 py-1">
-          <option>{orgId}</option>
-          {/* TODO: dynamic org list */}
-        </select>
-        <button className="border rounded px-3 py-1 text-sm">Create…</button>
-      </div>
-
-      <div className="flex items-center gap-4">
-        <Link href={`/org/${orgId}/alerts`} className="text-xl">
-          🔔
-        </Link>
-        <div className="w-8 h-8 rounded-full bg-gray-300" />
+        <Dialog>
+          <DialogTrigger className="btn">Create…</DialogTrigger>
+          <DialogContent className="max-w-lg">
+            <QuickActions />
+          </DialogContent>
+        </Dialog>
+        <AvatarMenu />
       </div>
     </header>
   );

--- a/src/components/reports/ReportRow.tsx
+++ b/src/components/reports/ReportRow.tsx
@@ -1,0 +1,20 @@
+import { mutate } from "swr";
+import { toastError } from "@/lib/toast";
+
+async function regenerate(id: string) {
+  try {
+    await fetch(`/api/reports/${id}/regenerate`, { method: "POST" });
+    mutate("/api/reports");
+  } catch (e) {
+    toastError("Could not regenerate", () => regenerate(id));
+  }
+}
+
+export default function ReportRow({ report }: { report: any }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span>{report.name}</span>
+      <button onClick={() => regenerate(report.id)} className="link">Regenerate</button>
+    </div>
+  );
+}

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -1,0 +1,25 @@
+import {
+  LayoutDashboard, BezierCurve, ActivitySquare, FileText,
+  Plug, Layers, AlertTriangle, BarChart,
+  Clock, Wrench, Bot, Wallet, Leaf, Tag, Settings,
+} from "lucide-react";
+
+export const Icons = {
+  dashboard: LayoutDashboard,
+  router: BezierCurve,
+  pulse: ActivitySquare,
+  ledger: FileText,
+  plug: Plug,
+  stack: Layers,
+  alert: AlertTriangle,
+  report: BarChart,
+  scheduler: Clock,
+  advisor: Wrench,
+  bot: Bot,
+  budget: Wallet,
+  offsets: Leaf,
+  ecolabel: Tag,
+  settings: Settings,
+};
+
+export type IconName = keyof typeof Icons;

--- a/src/components/widgets/CarbonBadge.tsx
+++ b/src/components/widgets/CarbonBadge.tsx
@@ -1,4 +1,14 @@
-export default function CarbonBadge({ value }: { value: number }) {
+"use client";
+import { useEffect, useState } from "react";
+
+export default function CarbonBadge({ orgId, range }: { orgId: string; range: string }) {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    fetch(`/api/org/${orgId}/carbon?range=${range}`)
+      .then(r => r.json())
+      .then(d => setValue(d.total ?? 0))
+      .catch(() => setValue(0));
+  }, [orgId, range]);
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs">
       🌿 {value.toFixed(1)} kg CO₂

--- a/src/components/widgets/LiveStreamToggle.tsx
+++ b/src/components/widgets/LiveStreamToggle.tsx
@@ -1,25 +1,16 @@
 "use client";
-import { useState } from "react";
-
 export default function LiveStreamToggle({
-  enabled,
-  onToggle,
-}: {
-  enabled: boolean;
-  onToggle: (v: boolean) => void;
-}) {
-  const [state, setState] = useState(enabled);
+  enabled, onToggle,
+}: { enabled: boolean; onToggle: (v: boolean) => void }) {
   return (
-    <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+    <label className="flex items-center gap-2 cursor-pointer select-none">
       <input
         type="checkbox"
-        checked={state}
-        onChange={(e) => {
-          setState(e.target.checked);
-          onToggle(e.target.checked);
-        }}
+        checked={enabled}
+        onChange={(e) => onToggle(e.target.checked)}
+        className="toggle"
       />
-      Live stream
+      Live
     </label>
   );
 }

--- a/src/components/widgets/TimeRangePicker.tsx
+++ b/src/components/widgets/TimeRangePicker.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export type Range = "7d" | "30d" | "custom";
 
 export default function TimeRangePicker({
+  value,
   onChange,
 }: {
+  value: Range;
   onChange: (r: Range, custom?: [Date, Date]) => void;
 }) {
-  const [range, setRange] = useState<Range>("7d");
+  const [range, setRange] = useState<Range>(value);
+  // sync when parent changes
+  useEffect(() => setRange(value), [value]);
 
   return (
     <div className="inline-flex border rounded overflow-hidden">

--- a/src/lib/hooks/useSSE.ts
+++ b/src/lib/hooks/useSSE.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useSSE<T>(url: string, enabled = true) {
+  const [data, set] = useState<T | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const es = new EventSource(url);
+    es.onmessage = (e) => set(JSON.parse(e.data));
+    es.onerror = () => es.close();
+    return () => es.close();
+  }, [url, enabled]);
+
+  return data;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,13 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: {} },
+    ar: { translation: {} },
+  },
+  lng: "en",
+  fallbackLng: "en",
+  interpolation: { escapeValue: false },
+});
+export default i18n;

--- a/src/lib/mocks/handlers.ts
+++ b/src/lib/mocks/handlers.ts
@@ -125,4 +125,17 @@ export const handlers = [
     )
   ),
 
+  rest.get("/api/org/:id/router/logs/stream", (_req, res, ctx) =>
+    ctx.eventStream((send) =>
+      setInterval(() => send({ data: JSON.stringify({ ts: Date.now(), msg: "fake log"}) }), 3000),
+    ),
+  ),
+  rest.get("/api/org/:id/balance-trend", (_req, res, ctx) =>
+    res(
+      ctx.json(Array.from({ length: 30 }, (_, i) => ({
+        day: i, balance: 10_000 + Math.random() * 5_000,
+      })))
+    ),
+  ),
+
 ];

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,4 +1,11 @@
-export type NavItem = { href: string; label: string; icon: string; flag?: string };
+import type { IconName } from "@/components/ui/Icons";
+
+export type NavItem = {
+  href: string;
+  label: string;
+  icon: IconName;          // ← NEW strict type
+  flag?: string;
+};
 
 export const NAV_BY_ROLE: Record<string, NavItem[]> = {
   developer: [
@@ -6,30 +13,30 @@ export const NAV_BY_ROLE: Record<string, NavItem[]> = {
     { href: "/plugins", label: "Plugins", icon: "plug" },
     { href: "/projects", label: "Projects", icon: "stack" },
     { href: "/alerts", label: "Alerts", icon: "alert" },
-    { href: "/router", label: "Router", icon: "🗺", flag: "router" },
-    { href: "/pulse", label: "Pulse", icon: "💓", flag: "pulse" },
-    { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/scheduler", label: "Scheduler", icon: "⏱", flag: "scheduler" },
-    { href: "/iac-advisor", label: "IaC Advisor", icon: "🛠", flag: "iac-advisor" },
-    { href: "/greendev", label: "GreenDev Bot", icon: "🤖", flag: "greendev" },
+    { href: "/router", label: "Router", icon: "router", flag: "router" },
+    { href: "/pulse", label: "Pulse", icon: "pulse", flag: "pulse" },
+    { href: "/ledger", label: "Ledger", icon: "ledger" },
+    { href: "/scheduler", label: "Scheduler", icon: "scheduler", flag: "scheduler" },
+    { href: "/iac-advisor", label: "IaC Advisor", icon: "advisor", flag: "iac-advisor" },
+    { href: "/greendev", label: "GreenDev Bot", icon: "bot", flag: "greendev" },
     { href: "/comply", label: "Comply", icon: "report", flag: "comply" }
   ],
   finops: [
-    { href: "/dashboard", label: "Dashboard", icon: "📊" },
-    { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/budget", label: "Budget", icon: "💶", flag: "budget" },
-    { href: "/offsets", label: "Offsets", icon: "🌿" },
-    { href: "/alerts", label: "Alerts", icon: "🚨" }
+    { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
+    { href: "/ledger", label: "Ledger", icon: "ledger" },
+    { href: "/budget", label: "Budget", icon: "budget", flag: "budget" },
+    { href: "/offsets", label: "Offsets", icon: "offsets" },
+    { href: "/alerts", label: "Alerts", icon: "alert" }
   ],
   sustainability: [
-    { href: "/dashboard", label: "Dashboard", icon: "📊" },
-    { href: "/ledger", label: "Ledger", icon: "📜" },
-    { href: "/reports", label: "Reports", icon: "📄" },
-    { href: "/ecolabel", label: "EcoLabel", icon: "🏷" },
-    { href: "/offsets", label: "Offsets", icon: "🌳" },
-    { href: "/comply", label: "Comply", icon: "📄", flag: "comply" }
+    { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
+    { href: "/ledger", label: "Ledger", icon: "ledger" },
+    { href: "/reports", label: "Reports", icon: "report" },
+    { href: "/ecolabel", label: "EcoLabel", icon: "ecolabel" },
+    { href: "/offsets", label: "Offsets", icon: "offsets" },
+    { href: "/comply", label: "Comply", icon: "report", flag: "comply" }
   ],
-  admin: [{ href: "/settings", label: "Settings", icon: "⚙️" }]
+  admin: [{ href: "/settings", label: "Settings", icon: "settings" }]
 } as const;
 
 export type Role = keyof typeof NAV_BY_ROLE;

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -5,5 +5,6 @@ export const AppToaster = () => <Toaster position="top-right" richColors />;
 
 export const toastSuccess = (msg: string) =>
   toast(msg, { className: "bg-green-600 text-white" });
-export const toastError = (msg: string) =>
-  toast(msg, { className: "bg-red-600 text-white" });
+export function toastError(msg: string, retry?: () => void) {
+  toast.error(msg, retry && { action: { label: "Retry", onClick: retry } });
+}


### PR DESCRIPTION
## Summary
- hook up dynamic org switcher and create modal
- enable global toasts and i18n
- centralize icon map and update navigation
- add generic SSE hook and ledger live mode
- update LiveStreamToggle
- add time range picker with carbon badge
- scaffold plugin deep routes
- toast helper for retry
- template manager and audit export
- extra MSW handlers
- add playwright e2e example

## Testing
- `npm run dev` *(fails: next not found)*
- `npm test` *(fails: missing script)*
- `pnpm exec playwright test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f68c1108322b47b25563974a5f9