### PR TITLE
Implement dashboard enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,8 @@ jobs:
       - run: pnpm test -- --run
       - run: pnpm exec playwright install --with-deps
       - run: pnpm exec playwright test
+      - name: Build (strict mode)
+        run: |
+          pnpm install --frozen-lockfile
+          CI=true pnpm exec next build
+      - run: lhci autorun || true

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -7,3 +7,9 @@ test("dashboard shows KPI cards & ledger filter", async ({ page }) => {
   await page.locator("text=backend-api").click();
   await expect(page.url()).toContain("project=backend-api");
 });
+
+test("quick actions modal opens", async ({ page }) => {
+  await page.goto("/org/1/dashboard");
+  await page.getByText("Create budget").click();
+  await expect(page.getByRole("button", { name: "Create" })).toBeVisible();
+});

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  ci: {
+    collect: {
+      url: ["http://localhost:3000/org/1/dashboard"],
+      startServerCommand: "pnpm exec next start -p 3000",
+      numberOfRuns: 1
+    },
+    assert: {
+      preset: "lighthouse:no-pwa",
+      assertions: { "categories:performance": ["error", {minScore: .9}],
+                    "categories:accessibility": ["error", {minScore: .9}] }
+    }
+  }
+};

--- a/src/app/api/analytics/web-vitals/route.ts
+++ b/src/app/api/analytics/web-vitals/route.ts
@@ -1,0 +1,7 @@
+import { CARBONCORE_URL } from "@/lib/env";
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  await fetch(`${CARBONCORE_URL}/vitals`, { method: "POST", body });
+  return new Response(null, { status: 202 });
+}

--- a/src/app/api/proxy/org/[orgId]/snapshot/route.ts
+++ b/src/app/api/proxy/org/[orgId]/snapshot/route.ts
@@ -1,0 +1,12 @@
+import { CARBONCORE_URL } from "@/lib/env";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { orgId: string } }
+) {
+  const res = await fetch(`${CARBONCORE_URL}/org/${params.orgId}/snapshot`);
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" }
+  });
+}

--- a/src/app/api/proxy/org/[orgId]/trend/route.ts
+++ b/src/app/api/proxy/org/[orgId]/trend/route.ts
@@ -1,0 +1,15 @@
+import { CARBONCORE_URL } from "@/lib/env";
+
+export async function GET(
+  req: Request,
+  { params }: { params: { orgId: string } }
+) {
+  const url = new URL(req.url);
+  const res = await fetch(
+    `${CARBONCORE_URL}/org/${params.orgId}/trend${url.search}`
+  );
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" }
+  });
+}

--- a/src/app/org/[orgId]/dashboard/page.tsx
+++ b/src/app/org/[orgId]/dashboard/page.tsx
@@ -1,14 +1,28 @@
 import { DashboardLayout }  from "@/components/dashboard/DashboardLayout";
-import { Suspense }          from "react";
+import { Suspense, useEffect }          from "react";
 import KpiGrid from "@/components/dashboard/KpiGrid";
-import { QuickActions }      from "@/components/dashboard/QuickActions";
+import QuickActions from "@/components/quick-actions/QuickActions.client";
 import { AlertBanner }       from "@/components/alerts/AlertBanner";
+import BudgetBanner from "@/components/budget/BudgetBanner";
+import { useGlobalShortcuts } from "@/lib/shortcuts";
+import { getSession } from "@/lib/auth";
 import { EmissionChart }     from "@/components/dashboard/EmissionChart.client";
 import { LedgerPreview }     from "@/components/ledger/LedgerPreview";
 import { PageMetrics }       from "@/components/dashboard/PageMetrics.client";
 import { PluginCards }       from "@/components/dashboard/PluginCards.client";
+import EcoShiftWidget from "@/components/product/EcoShiftWidget";
+import EcoEdgeWidget  from "@/components/product/EcoEdgeWidget";
+import TrendSection from "@/components/charts/TrendSection.client";
 import { fetchAlertCount }    from "@/lib/alerts-api";
 import { ChartSkeleton } from "@/components/ui/ChartSkeleton";
+
+function FocusHelper({ focusId, orgId }: { focusId: string; orgId: string }) {
+  useGlobalShortcuts(orgId);
+  useEffect(() => {
+    document.getElementById(focusId)?.scrollIntoView({ behavior: "smooth" });
+  }, [focusId]);
+  return null;
+}
 
 
 export default async function DashboardPage(
@@ -18,6 +32,13 @@ export default async function DashboardPage(
 ) {
   await Promise.resolve();
   const { orgId } = await props.params;
+  const { roles } = await getSession();
+  const focusId =
+    roles.includes("finance")
+      ? "budget-section"
+      : roles.includes("developer")
+        ? "ledger-section"
+        : "trend-section";
   // Server-side fetches (block render until resolved)
   const [alertCount] = await Promise.all([
     fetchAlertCount(orgId),
@@ -25,13 +46,20 @@ export default async function DashboardPage(
 
   return (
     <DashboardLayout>
+      <FocusHelper focusId={focusId} orgId={orgId} />
       <PageMetrics page="dashboard" />
       {/* Row 1 – alerts + quick actions */}
       <AlertBanner count={alertCount} />
       <QuickActions orgId={orgId} />
 
+      <div id="budget-section">
+        <BudgetBanner orgId={orgId} />
+      </div>
+
       {/* Row 2 – KPI grid (includes live RemainingBudget tile) */}
       <KpiGrid orgId={orgId} />
+
+      <TrendSection orgId={orgId} />
 
       {/* Row 3 – 30 day emissions vs budget chart */}
       {/* <Suspense fallback={<ChartSkeleton />}> */}
@@ -39,7 +67,14 @@ export default async function DashboardPage(
       {/* </Suspense> */}
 
       {/* Row 4 – recent ledger events */}
-      <LedgerPreview orgId={orgId} />
+      <div id="ledger-section">
+        <LedgerPreview orgId={orgId} />
+      </div>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <EcoShiftWidget orgId={orgId}/>
+        <EcoEdgeWidget  orgId={orgId}/>
+      </section>
 
       {/* Row 5 – plugin status */}
       <PluginCards orgId={orgId} />

--- a/src/app/org/[orgId]/ledger/ClientPage.tsx
+++ b/src/app/org/[orgId]/ledger/ClientPage.tsx
@@ -5,7 +5,9 @@ import TimeRangePicker, { Range } from "@/components/widgets/TimeRangePicker";
 import CarbonBadge from "@/components/widgets/CarbonBadge";
 import DownloadDropdown from "@/components/widgets/DownloadDropdown";
 import { LedgerTable  }from "@/components/ledger/LedgerTable.client";
-import FilterBar from "@/components/ledger/FilterBar";
+import Button from "@/components/ui/Button";
+import FilterBar from "@/components/ledger/filters/FilterBar.client";
+import { useLedgerFilters } from "@/components/ledger/filters/store";
 import BalanceTrendChart from "@/components/ledger/BalanceTrendChart";
 import LiveStreamToggle from "@/components/widgets/LiveStreamToggle";
 
@@ -18,6 +20,8 @@ export default function ClientPage({
 }) {
   const [range, setRange] = useState<Range | null>(null);
   const [live, setLive] = useState(false);
+  const { filters } = useLedgerFilters();
+  const qs = new URLSearchParams(filters as Record<string,string>).toString();
 
   return (
     <div className="space-y-6">
@@ -28,6 +32,11 @@ export default function ClientPage({
           {range && <CarbonBadge orgId={orgId} range={range} />}
           <LiveStreamToggle enabled={live} onToggle={setLive} />
           <DownloadDropdown endpoint={`/api/org/${orgId}/ledger/export`} />
+          <Button
+            onClick={() => window.open(
+              `/api/proxy/org/${orgId}/ledger/export?fmt=csv&${qs}`
+            )}
+          >CSV</Button>
         </div>
       </div>
 

--- a/src/app/reportWebVitals.ts
+++ b/src/app/reportWebVitals.ts
@@ -1,0 +1,4 @@
+export function reportWebVitals(metric) {
+  navigator.sendBeacon("/api/analytics/web-vitals",
+                       JSON.stringify(metric));
+}

--- a/src/components/alerts/AlertsPanel.client.tsx
+++ b/src/components/alerts/AlertsPanel.client.tsx
@@ -1,0 +1,39 @@
+"use client";
+import useSWR from "swr";
+import { useEffect, useState } from "react";
+import { Collapse } from "@radix-ui/react-collapse";
+
+export default function AlertsPanel({ orgId }: { orgId: string }) {
+  const { data: initial } = useSWR(`/api/proxy/org/${orgId}/alerts`);
+  const [alerts, setAlerts] = useState(initial ?? []);
+  const mute = (id: string) =>
+    fetch(`/api/proxy/alerts/${id}/mute`, { method: "PATCH" })
+      .then(() => setAlerts(a => a.filter((x: any) => x.id !== id)));
+
+  useEffect(() => {
+    const es = new EventSource(`/sse/alerts?org=${orgId}`);
+    es.onmessage = e => setAlerts(a => [JSON.parse(e.data), ...a]);
+    return () => es.close();
+  }, [orgId]);
+
+  if (!alerts) return null;
+
+  return (
+    <section className="rounded border p-4">
+      <h2 className="font-medium mb-2">Alerts</h2>
+      {alerts.map((al: any) => (
+        <div key={al.id} className="flex items-start gap-2 py-1">
+          <div className="grow">
+            <p className="text-sm">{al.msg}</p>
+            <small className="text-xs text-muted">
+              {new Date(al.ts).toLocaleString()}
+            </small>
+          </div>
+          <button onClick={() => mute(al.id)} className="text-xs underline">
+            mute
+          </button>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/components/budget/BudgetBanner.tsx
+++ b/src/components/budget/BudgetBanner.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Switch } from "@/components/ui/Switch";
+import { Input } from "@/components/ui/Input";
+import BudgetSparkline from "./BudgetSparkline";
+
+export default function BudgetBanner({ orgId }: { orgId: string }) {
+  const { data } = useQuery({
+    queryKey: ["budget", orgId],
+    queryFn: () => fetch(`/api/proxy/org/${orgId}/budget`).then(r => r.json())
+  });
+  const queryClient = useQueryClient();
+
+  const mPrice = useMutation({
+    mutationFn: (val: number) =>
+      fetch(`/api/proxy/org/${orgId}/budget/price`, {
+        method: "PUT",
+        body: JSON.stringify({ price: val })
+      }),
+    onSuccess: () => queryClient.invalidateQueries(["budget", orgId])
+  });
+  const mSlack = useMutation({
+    mutationFn: (val: boolean) =>
+      fetch(`/api/proxy/org/${orgId}/alerts/budget`, {
+        method: "PATCH",
+        body: JSON.stringify({ slack: val })
+      })
+  });
+
+  if (!data) return <div className="h-24"/>;
+
+  return (
+    <section className="rounded border p-4 flex flex-col gap-2">
+      <h2 className="text-lg font-medium">Carbon Budget</h2>
+      <div className="flex items-center gap-4">
+        <span>Internal price € / t:</span>
+        <Input
+          type="number"
+          defaultValue={data.price}
+          onBlur={e => mPrice.mutate(+e.target.value)}
+          className="w-24"
+        />
+        <span className="ml-auto">Slack alert</span>
+        <Switch
+          checked={data.slack}
+          onCheckedChange={v => mSlack.mutate(v)}
+        />
+      </div>
+      <BudgetSparkline orgId={orgId} />
+    </section>
+  );
+}

--- a/src/components/budget/BudgetSparkline.tsx
+++ b/src/components/budget/BudgetSparkline.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { Line } from "react-chartjs-2";
+import useSWR from "swr";
+
+export default function BudgetSparkline({ orgId }:{ orgId:string }) {
+  const { data } = useSWR(`/api/proxy/org/${orgId}/budget/trend`, u=>fetch(u).then(r=>r.json()));
+  if (!data) return <div className="h-16"/>;
+  const points = data.map((p:any)=>({ x: p.ts, y: p.v }));
+  return <Line data={{datasets:[{data:points}]}} options={{plugins:{legend:{display:false}},scales:{x:{display:false},y:{display:false}}}} />;
+}

--- a/src/components/charts/TrendChart.client.tsx
+++ b/src/components/charts/TrendChart.client.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { Line } from "react-chartjs-2";
+import useSWR from "swr";
+import { ChartDataset } from "chart.js";
+
+export default function TrendChart({
+  orgId, period, series
+}: {
+  orgId: string;
+  period: string;
+  series: string[];
+}) {
+  const buck = ["7d"].includes(period) ? "hour" : "day";
+  const { data } = useSWR(
+    `/api/proxy/org/${orgId}/trend?period=${period}&bucket=${buck}&series=${series.join(",")}`,
+    (u) => fetch(u).then(r => r.json())
+  );
+  if (!data) return <div className="h-64"/>;
+
+  const datasets: ChartDataset<"line">[] = data.map((s: any) => ({
+    label: s.label,
+    data: s.points.map((p: any) => ({ x: p.ts, y: p.v })),
+    tension: 0.3,
+    fill: "origin"
+  }));
+
+  return <Line data={{ datasets }} options={{ normalized: true }}/>
+}

--- a/src/components/charts/TrendSection.client.tsx
+++ b/src/components/charts/TrendSection.client.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useState } from "react";
+import TrendChart from "./TrendChart.client";
+import { DateRangePicker } from "@/components/ui/DateRangePicker";
+
+export default function TrendSection({ orgId }: { orgId: string }) {
+  const [period, setPeriod] = useState<"7d" | "30d" | "90d" | "custom">("30d");
+
+  return (
+    <section className="space-y-6" id="trend-section">
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-medium">Trends</h2>
+        <DateRangePicker period={period} onChange={setPeriod}/>
+      </header>
+
+      <TrendChart
+        orgId={orgId}
+        period={period}
+        series={["emissions_by_project", "grid_intensity"]}
+      />
+      <TrendChart
+        orgId={orgId}
+        period={period}
+        series={["savings", "offsets"]}
+      />
+    </section>
+  );
+}

--- a/src/components/dashboard/KpiGrid.tsx
+++ b/src/components/dashboard/KpiGrid.tsx
@@ -1,25 +1,17 @@
-import SnapshotCard from "./SnapshotCard";
-import { useOrgSnapshot } from "@/lib/queries/useOrgSnapshot";
+"use client";
+import { StatCard, SkeletonCards } from "@/components/ui/StatCard";
+import { useOrgSnapshot } from "@/hooks/useOrgSnapshot";
 
-export default async function KpiGrid({ orgId }: { orgId: string }) {
-  const snapshot = await useOrgSnapshot(orgId);
+export default function KpiGrid({ orgId }: { orgId: string }) {
+  const snap = useOrgSnapshot(orgId);
+
+  if (!snap) return <SkeletonCards/>;
   return (
-    <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-      <SnapshotCard
-        label="Total savings"
-        value={`$${snapshot.total.toLocaleString()}`}
-        trend={snapshot.totalTrend}
-      />
-      <SnapshotCard
-        label="CO₂ avoided"
-        value={`${snapshot.co2.toFixed(1)} t`}
-        trend={snapshot.co2Trend}
-      />
-      <SnapshotCard
-        label="Top project"
-        value={snapshot.topProject.name}
-        trend={snapshot.topProject.trend}
-      />
-    </section>
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard label="Total emissions YTD" value={snap.ytd_co2_t} unit="t" />
+      <StatCard label="€ saved YTD"        value={snap.ytd_money}  unit="€" />
+      <StatCard label="kWh avoided YTD"    value={snap.ytd_kwh}    unit="kWh" />
+      <StatCard label="Projects w/ budget" value={snap.budgeted_projects} />
+    </div>
   );
 }

--- a/src/components/ledger/EventDrawer.client.tsx
+++ b/src/components/ledger/EventDrawer.client.tsx
@@ -1,0 +1,14 @@
+import { Dialog, DialogTrigger, DialogContent } from "@radix-ui/react-dialog";
+
+export function EventDrawer({ event, children }: any) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <pre className="text-xs overflow-auto">
+          {JSON.stringify(event, null, 2)}
+        </pre>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ledger/filters/FilterBar.client.tsx
+++ b/src/components/ledger/filters/FilterBar.client.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { Combobox } from "@/components/ui/Combobox";
+import { useLedgerFilters } from "./store";
+
+export default function FilterBar() {
+  const { filters, set } = useLedgerFilters();
+  return (
+    <div className="flex gap-2">
+      <Combobox placeholder="Project" onChange={v => set({ project: v })}/>
+      <Combobox placeholder="Plugin"  onChange={v => set({ plugin: v })}/>
+      <Combobox placeholder="SKU"     onChange={v => set({ sku: v })}/>
+      <Combobox
+        placeholder="Type"
+        options={["emission","saving","offset"]}
+        onChange={v => set({ type: v as any })}
+      />
+    </div>
+  );
+}

--- a/src/components/ledger/filters/store.ts
+++ b/src/components/ledger/filters/store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type Filters = {
+  project?: string;
+  plugin?: string;
+  sku?: string;
+  type?: "emission" | "saving" | "offset";
+};
+export const useLedgerFilters = create<{
+  filters: Filters;
+  set: (f: Partial<Filters>) => void;
+}>(set => ({
+  filters: {},
+  set: f => set(s => ({ filters: { ...s.filters, ...f } }))
+}));

--- a/src/components/product/EcoEdgeWidget.client.tsx
+++ b/src/components/product/EcoEdgeWidget.client.tsx
@@ -1,0 +1,16 @@
+import { Leaf } from "lucide-react";
+import { ProductWidget } from "./ProductWidget";
+
+export default function EcoEdgeWidget({ orgId }: { orgId: string }) {
+  return (
+    <ProductWidget
+      orgId={orgId}
+      icon={Leaf}
+      title="EcoEdge Summary"
+      endpoint={`/ecoedge/summary`}
+      render={(d: any) => (
+        <div className="text-sm">{d.message}</div>
+      )}
+    />
+  );
+}

--- a/src/components/product/EcoShiftWidget.client.tsx
+++ b/src/components/product/EcoShiftWidget.client.tsx
@@ -1,0 +1,23 @@
+import { Clock } from "lucide-react";
+import { ProductWidget } from "./ProductWidget";
+
+export default function EcoShiftWidget({ orgId }: { orgId: string }) {
+  return (
+    <ProductWidget
+      orgId={orgId}
+      icon={Clock}
+      title="EcoShift Jobs"
+      endpoint={`/scheduler/shifts?limit=5`}
+      render={(jobs: any[]) => (
+        <ul className="text-sm space-y-1">
+          {jobs.map(j => (
+            <li key={j.id}>
+              <b>{j.name}</b>&nbsp;
+              <span className="text-muted">– {j.kwh_saved} kWh saved</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    />
+  );
+}

--- a/src/components/product/ProductWidget.tsx
+++ b/src/components/product/ProductWidget.tsx
@@ -1,0 +1,27 @@
+"use client";
+import useSWR from "swr";
+import { Card } from "@/components/ui/Card";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+export function ProductWidget<T>({
+  orgId, icon: Icon, title, endpoint, render
+}: {
+  orgId: string;
+  icon: React.FC<any>;
+  title: string;
+  endpoint: string;
+  render: (data: T) => React.ReactNode;
+}) {
+  const { data, error } = useSWR<T>(`/api/proxy/org/${orgId}${endpoint}`, (u) =>
+    fetch(u).then(r => r.json())
+  );
+  if (error) return <Card title={title}><p>error</p></Card>;
+  if (!data) return <Skeleton className="h-24 w-full"/>;
+
+  return (
+    <Card title={title}>
+      <Icon className="w-5 h-5 inline mr-2"/>
+      {render(data)}
+    </Card>
+  );
+}

--- a/src/components/quick-actions/BudgetForm.client.tsx
+++ b/src/components/quick-actions/BudgetForm.client.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { toastSuccess } from "@/lib/toast";
+
+export default function BudgetForm({ orgId }: { orgId: string }) {
+  const { register, handleSubmit } = useForm<{ project: string; cap: number }>();
+  const onSubmit = (v: any) =>
+    fetch(`/api/proxy/org/${orgId}/budgets`, {
+      method: "POST",
+      body: JSON.stringify(v)
+    }).then(() => toastSuccess("Budget created"));
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <input {...register("project")} placeholder="Project ID" required/>
+      <input {...register("cap",{valueAsNumber:true})} type="number"
+             placeholder="t CO₂ cap" required/>
+      <button className="btn-primary w-full">Create</button>
+    </form>
+  );
+}

--- a/src/components/quick-actions/ComplianceReportForm.client.tsx
+++ b/src/components/quick-actions/ComplianceReportForm.client.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { toastSuccess } from "@/lib/toast";
+
+export default function ComplianceReportForm({ orgId }: { orgId: string }) {
+  const { register, handleSubmit } = useForm<{ period: string }>();
+  const onSubmit = (v: any) =>
+    fetch(`/api/proxy/org/${orgId}/reports/compliance`, {
+      method: "POST",
+      body: JSON.stringify(v)
+    }).then(() => toastSuccess("Report requested"));
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <input {...register("period")} placeholder="Period" required/>
+      <button className="btn-primary w-full">Generate</button>
+    </form>
+  );
+}

--- a/src/components/quick-actions/InviteForm.client.tsx
+++ b/src/components/quick-actions/InviteForm.client.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { toastSuccess } from "@/lib/toast";
+
+export default function InviteForm({ orgId }: { orgId: string }) {
+  const { register, handleSubmit } = useForm<{ email: string }>();
+  const onSubmit = (v: any) =>
+    fetch(`/api/proxy/org/${orgId}/invite`, {
+      method: "POST",
+      body: JSON.stringify(v)
+    }).then(() => toastSuccess("Invite sent"));
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <input {...register("email")} type="email" placeholder="Email" required/>
+      <button className="btn-primary w-full">Invite</button>
+    </form>
+  );
+}

--- a/src/components/quick-actions/QuickActions.client.tsx
+++ b/src/components/quick-actions/QuickActions.client.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { Dialog, DialogTrigger, DialogContent } from "@radix-ui/react-dialog";
+import BudgetForm from "./BudgetForm.client";
+import InviteForm from "./InviteForm.client";
+import ComplianceReportForm from "./ComplianceReportForm.client";
+
+export default function QuickActions({ orgId }: { orgId: string }) {
+  return (
+    <Dialog>
+      <DialogTrigger className="btn-secondary">Create budget</DialogTrigger>
+      <DialogContent><BudgetForm orgId={orgId}/></DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/StatCard.tsx
+++ b/src/components/ui/StatCard.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Card } from "./Card";
+
+export function StatCard({ label, value, unit }:{label:string; value:number; unit?:string}){
+  return (
+    <Card className="p-4 space-y-1">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-2xl font-semibold">
+        {value}{unit && <span className="text-base ml-1">{unit}</span>}
+      </p>
+    </Card>
+  );
+}
+
+export function SkeletonCards() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({length:4}).map((_,i)=>(
+        <Card key={i} className="h-20 animate-pulse bg-muted" />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,3 +13,4 @@ export { Combobox } from './Combobox';
 export { Dialog, DialogTrigger, DialogContent } from './Dialog';
 export { default as Tabs } from './Tabs';
 export { Slider } from './Slider';
+export { StatCard, SkeletonCards } from "./StatCard";

--- a/src/hooks/__tests__/useOrgSnapshot.test.ts
+++ b/src/hooks/__tests__/useOrgSnapshot.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from "@testing-library/react";
+import { useOrgSnapshot } from "../useOrgSnapshot";
+import { server, rest } from "@/test/msw";
+
+test("returns snapshot values", async () => {
+  server.use(rest.get("/api/proxy/org/1/snapshot",
+    (_,_res,ctx) => ctx.json({ ytd_co2_t: 12 })));
+  const { result, waitFor } = renderHook(() => useOrgSnapshot("1", false));
+  await waitFor(() => expect(result.current).toBeDefined());
+  expect(result.current!.ytd_co2_t).toBe(12);
+});

--- a/src/hooks/useOrgSnapshot.ts
+++ b/src/hooks/useOrgSnapshot.ts
@@ -1,0 +1,21 @@
+import useSWR from "swr";
+import { useEffect } from "react";
+
+const fetcher = (u: string) => fetch(u).then(r => r.json());
+
+export function useOrgSnapshot(orgId: string, live = true) {
+  const { data, mutate } = useSWR(
+    `/api/proxy/org/${orgId}/snapshot`,
+    fetcher,
+    { refreshInterval: 30_000 }
+  );
+
+  useEffect(() => {
+    if (!live) return;
+    const es = new EventSource(`/sse/snapshot?org=${orgId}`);
+    es.onmessage = e => mutate(JSON.parse(e.data), false);
+    return () => es.close();
+  }, [live, orgId, mutate]);
+
+  return data;
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,12 @@
+import hotkeys from "hotkeys-js";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function useGlobalShortcuts(orgId: string) {
+  const router = useRouter();
+  useEffect(() => {
+    hotkeys("g l", () => router.push(`/org/${orgId}/ledger`));
+    hotkeys("g r", () => document.querySelector("#quick-actions")?.click());
+    return () => hotkeys.unbind("g l,g r");
+  }, [orgId, router]);
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,9 @@
+export function downloadCsv(rows: any[], filename = "export.csv") {
+  const header = Object.keys(rows[0]).join(",");
+  const body   = rows.map(r => Object.values(r).join(",")).join("\n");
+  const blob   = new Blob([header + "\n" + body], { type: "text/csv" });
+  const url    = URL.createObjectURL(blob);
+  const a      = document.createElement("a");
+  a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add API proxies for snapshots and trends
- create live Org snapshot hook
- enhance dashboard with budget banner, trend section, and product widgets
- integrate role focus and keyboard shortcuts
- add ledger filters and export features
- add web vitals endpoint and tests

## Testing
- `pnpm vitest run --coverage` *(fails: vitest not found)*
- `pnpm exec playwright test` *(fails: playwright not found)*
- `pnpm exec next build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dac1d878083229b90602066b6a835