### PR TITLE
Fix dashboard params awaiting and mark product widgets as client components

### DIFF
--- a/src/app/org/[orgId]/dashboard/page.tsx
+++ b/src/app/org/[orgId]/dashboard/page.tsx
@@ -33,7 +33,7 @@ export default async function DashboardPage({
   // ─────────────────────────────────────────────────────────────
   // 2. Server fetches that block initial render
   // ─────────────────────────────────────────────────────────────
-  const { orgId }  = params;
+  const { orgId }  = await params;
   const alertCount = await fetchAlertCount(orgId);
 
   // ─────────────────────────────────────────────────────────────

--- a/src/components/product/EcoEdgeWidget.tsx
+++ b/src/components/product/EcoEdgeWidget.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Leaf } from "lucide-react";
 import { ProductWidget } from "./ProductWidget";
 

--- a/src/components/product/EcoShiftWidget.tsx
+++ b/src/components/product/EcoShiftWidget.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Clock } from "lucide-react";
 import { ProductWidget } from "./ProductWidget";
 


### PR DESCRIPTION
## Summary
- await `params` before reading `orgId`
- declare mini widgets as client components

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd8ec009c83228b3e072b46a2636d