### PR TITLE
Fix org API proxies and stub data

### DIFF
--- a/src/app/api/orgs/route.ts
+++ b/src/app/api/orgs/route.ts
@@ -1,21 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-
-const backend = process.env.BACKEND_URL;
-
-export async function GET(req: NextRequest) {
-  if (!backend) {
-    console.error("BACKEND_URL env var is missing");
-    return NextResponse.json(
-      { error: "BACKEND_URL not set" },
-      { status: 500 }
-    );
-  }
-
-  const url  = `${backend}/orgs`;
-  const resp = await fetch(url, {
-    headers: { Authorization: req.headers.get("Authorization")! },
-    cache:   "no-store",
-  });
-
-  return NextResponse.json(await resp.json(), { status: resp.status });
+export const runtime = "nodejs";
+export async function GET() {
+  return Response.json([{ id: "1", name: "Demo Org" }]);
 }
+

--- a/src/app/api/proxy/org/[orgId]/budget/route.ts
+++ b/src/app/api/proxy/org/[orgId]/budget/route.ts
@@ -1,0 +1,7 @@
+import { proxy } from "@/lib/proxy";
+
+export async function GET(req: Request, { params }: { params: Promise<{ orgId: string }> }) {
+  const { orgId } = await params;
+  return proxy(req, `/org/${orgId}/budget`);
+}
+

--- a/src/app/api/proxy/org/[orgId]/ecoedge/summary/route.ts
+++ b/src/app/api/proxy/org/[orgId]/ecoedge/summary/route.ts
@@ -1,0 +1,7 @@
+import { proxy } from "@/lib/proxy";
+
+export async function GET(req: Request, { params }: { params: Promise<{ orgId: string }> }) {
+  const { orgId } = await params;
+  return proxy(req, `/org/${orgId}/ecoedge/summary`);
+}
+

--- a/src/app/api/proxy/org/[orgId]/scheduler/shifts/route.ts
+++ b/src/app/api/proxy/org/[orgId]/scheduler/shifts/route.ts
@@ -1,0 +1,7 @@
+import { proxy } from "@/lib/proxy";
+
+export async function GET(req: Request, { params }: { params: Promise<{ orgId: string }> }) {
+  const { orgId } = await params;
+  return proxy(req, `/org/${orgId}/scheduler/shifts`);
+}
+

--- a/src/app/api/proxy/org/[orgId]/snapshot/route.ts
+++ b/src/app/api/proxy/org/[orgId]/snapshot/route.ts
@@ -1,12 +1,9 @@
-import { CARBONCORE_URL } from "@/lib/env";
+import { proxy } from "@/lib/proxy";
 
 export async function GET(
-  _req: Request,
-  { params }: { params: { orgId: string } }
+  req: Request,
+  { params }: { params: Promise<{ orgId: string }> }
 ) {
-  const res = await fetch(`${CARBONCORE_URL}/org/${params.orgId}/snapshot`);
-  return new Response(await res.text(), {
-    status: res.status,
-    headers: { "Content-Type": "application/json" }
-  });
+  const { orgId } = await params;
+  return proxy(req, `/org/${orgId}/snapshot`);
 }

--- a/src/app/api/proxy/org/[orgId]/trend/route.ts
+++ b/src/app/api/proxy/org/[orgId]/trend/route.ts
@@ -1,15 +1,10 @@
-import { CARBONCORE_URL } from "@/lib/env";
+import { proxy } from "@/lib/proxy";
 
 export async function GET(
   req: Request,
-  { params }: { params: { orgId: string } }
+  { params }: { params: Promise<{ orgId: string }> }
 ) {
+  const { orgId } = await params;
   const url = new URL(req.url);
-  const res = await fetch(
-    `${CARBONCORE_URL}/org/${params.orgId}/trend${url.search}`
-  );
-  return new Response(await res.text(), {
-    status: res.status,
-    headers: { "Content-Type": "application/json" }
-  });
+  return proxy(req, `/org/${orgId}/trend${url.search}`);
 }

--- a/src/app/org/[orgId]/ecolabel/layout.tsx
+++ b/src/app/org/[orgId]/ecolabel/layout.tsx
@@ -6,7 +6,7 @@ export default function RouterLayout({ children }: LayoutProps) {
     <div className="space-y-6">
       <nav className="tabs">
         <Link href="./overview">Overview</Link>
-        <Link href="./experiments">Experiments</Link>
+        {/* <Link href="./experiments">Experiments</Link> */}
         <Link href="./logs">Logs</Link>
       </nav>
       {children}

--- a/src/app/org/[orgId]/offset-sync/layout.tsx
+++ b/src/app/org/[orgId]/offset-sync/layout.tsx
@@ -6,7 +6,7 @@ export default function RouterLayout({ children }: LayoutProps) {
     <div className="space-y-6">
       <nav className="tabs">
         <Link href="./overview">Overview</Link>
-        <Link href="./experiments">Experiments</Link>
+        {/* <Link href="./experiments">Experiments</Link> */}
         <Link href="./logs">Logs</Link>
       </nav>
       {children}

--- a/src/app/org/[orgId]/pulse/layout.tsx
+++ b/src/app/org/[orgId]/pulse/layout.tsx
@@ -6,7 +6,7 @@ export default function PulseLayout({ children }: LayoutProps) {
     <div className="space-y-6">
       <nav className="tabs">
         <Link href="./overview">Overview</Link>
-        <Link href="./experiments">Experiments</Link>
+        {/* <Link href="./experiments">Experiments</Link> */}
         <Link href="./logs">Logs</Link>
       </nav>
       {children}

--- a/src/app/org/[orgId]/router/layout.tsx
+++ b/src/app/org/[orgId]/router/layout.tsx
@@ -6,7 +6,7 @@ export default function RouterLayout({ children }: LayoutProps) {
     <div className="space-y-6">
       <nav className="tabs">
         <Link href="./overview">Overview</Link>
-        <Link href="./experiments">Experiments</Link>
+        {/* <Link href="./experiments">Experiments</Link> */}
         <Link href="./logs">Logs</Link>
       </nav>
       {children}

--- a/src/app/org/[orgId]/scheduler/layout.tsx
+++ b/src/app/org/[orgId]/scheduler/layout.tsx
@@ -6,7 +6,7 @@ export default function RouterLayout({ children }: LayoutProps) {
     <div className="space-y-6">
       <nav className="tabs">
         <Link href="./overview">Overview</Link>
-        <Link href="./experiments">Experiments</Link>
+        {/* <Link href="./experiments">Experiments</Link> */}
         <Link href="./logs">Logs</Link>
       </nav>
       {children}

--- a/src/app/sse/snapshot/route.ts
+++ b/src/app/sse/snapshot/route.ts
@@ -1,0 +1,9 @@
+import { proxy } from "@/lib/proxy";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const org = url.searchParams.get("org");
+  if (!org) return new Response("Missing org", { status: 400 });
+  return proxy(req, `/org/${org}/snapshot/stream`);
+}
+

--- a/src/fixtures/org/1/budget.json
+++ b/src/fixtures/org/1/budget.json
@@ -1,0 +1,2 @@
+{"price":100,"slack":false}
+

--- a/src/fixtures/org/1/projects.json
+++ b/src/fixtures/org/1/projects.json
@@ -1,0 +1,2 @@
+[{"id":"p1","name":"Demo Project"}]
+

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,2 @@
+export const CARBONCORE_URL = process.env.CARBONCORE_URL ?? "";
+

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -1,0 +1,22 @@
+import { CARBONCORE_URL } from "./env";
+import fs from "fs/promises";
+import path from "path";
+
+export async function proxy(req: Request, upstream: string) {
+  const url = `${CARBONCORE_URL}${upstream}`;
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (res.status === 404) {
+    const fixturePath = path.join(process.cwd(), "src/fixtures", `${upstream}.json`);
+    try {
+      const data = await fs.readFile(fixturePath, "utf8");
+      return new Response(data, { status: 200, headers: { "Content-Type": "application/json" } });
+    } catch {
+      // fallthrough
+    }
+  }
+  return new Response(await res.text(), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+


### PR DESCRIPTION
## Summary
- implement proxy helper with fixture fallback
- add CARBONCORE_URL env constant
- patch `/api/orgs` to return demo org
- add missing proxy routes for budget, scheduler, ecoedge and snapshot SSE
- await params in proxy handlers
- guard EventSource in `useOrgSnapshot`
- comment out experimental links
- add sample fixtures for budget and projects

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e764a3930832282f6dfc2af39fc10